### PR TITLE
Fix timeout subprocess

### DIFF
--- a/src/twister2/device/native_simulator_adapter.py
+++ b/src/twister2/device/native_simulator_adapter.py
@@ -81,7 +81,6 @@ class NativeSimulatorAdapter(DeviceAbstract):
 
         return threading.Thread(target=_read, daemon=True)
 
-    # @staticmethod
     def _wait_and_terminate_process(self, process: subprocess.Popen, timeout: float) -> threading.Thread:
         """Create Thread which kills a process after given time."""
         def _waiting():

--- a/src/twister2/exceptions.py
+++ b/src/twister2/exceptions.py
@@ -28,3 +28,7 @@ class TwisterFlashException(TwisterException):
 
 class TwisterRunException(TwisterException):
     """Any exception during executing."""
+
+
+class TwisterTimeoutExpired(TwisterException):
+    """Subprocess ended due to timeout."""

--- a/src/twister2/log.py
+++ b/src/twister2/log.py
@@ -18,8 +18,9 @@ def configure_logging(config: pytest.Config) -> None:
         log_file = os.path.join(output_dir, f'twister2_{worker_id}.log')
 
     log_format = '%(asctime)s:%(levelname)s:%(name)s: %(message)s'
-    log_level = config.getoption('--log-level') or logging.INFO
-    log_file = config.getoption('--log-file') or log_file
+    log_level = config.getoption('--log-level') or config.getini('log_level') or logging.INFO
+    log_file = config.getoption('--log-file') or config.getini('log_file') or log_file
+    log_format = config.getini('log_cli_format') or log_format
 
     default_config = {
         'version': 1,

--- a/src/twister2/report/test_plan_plugin.py
+++ b/src/twister2/report/test_plan_plugin.py
@@ -67,7 +67,7 @@ class TestPlanPlugin:
         # print summary to terminal
         terminalreporter.ensure_newline()
         for writer in self.writers:
-            terminalreporter.write_sep('-', f'generated testplan file: {writer.filename}', green=True)
+            terminalreporter.write_sep('-', f'generated testplan file: {writer.filename}')
 
     def _save_report(self, data: dict) -> None:
         """Loop over all writers and save report."""

--- a/src/twister2/report/test_results_plugin.py
+++ b/src/twister2/report/test_results_plugin.py
@@ -46,7 +46,6 @@ class TestResult:
         self.report = report
         self.config = config
         self.duration: float = getattr(report, 'duration', 0.0)
-        # self.message: str = report.longrepr
         self.message: str = report.longreprtext
         self.subtests: list = []
 
@@ -122,9 +121,7 @@ class TestResultsPlugin:
 
     def pytest_terminal_summary(self, terminalreporter):
         for writer in self.writers:
-            terminalreporter.write_sep(
-                '-', f'generated results report file: {writer.filename}', green=True
-            )
+            terminalreporter.write_sep('-', f'generated results report file: {writer.filename}')
 
     def _get_outcome(self, report: pytest.TestReport) -> str | None:
         if report.failed:


### PR DESCRIPTION
Simulation subprocess wasn't terminated properly after timeout (missing arguments in raise subprocess.TimeoutExpired). This PR fixes it. 
Also improving logging configuration (reading configuration from pytest.ini). 