### PR TITLE
log_parser: fix handling of ZEPHYR FATAL ERROR

### DIFF
--- a/src/twister2/fixtures/log_parser.py
+++ b/src/twister2/fixtures/log_parser.py
@@ -15,7 +15,7 @@ def log_parser(request: pytest.FixtureRequest, dut) -> HarnessLogParser | None:
     """Return log parser."""
     parser_name = request.function.spec.harness or 'harness'  # make harness default parser
     harness_config = request.function.spec.harness_config
-    fail_on_fault = True if 'ignore_faults' in request.function.spec.tags else False
+    fail_on_fault = False if 'ignore_faults' in request.function.spec.tags else True
 
     parser_class = LogParserFactory.get_parser(parser_name)
     yield parser_class(dut.out, harness_config=harness_config, fail_on_fault=fail_on_fault)

--- a/src/twister2/log_parser/harness_log_parser.py
+++ b/src/twister2/log_parser/harness_log_parser.py
@@ -62,11 +62,10 @@ class HarnessLogParser(LogParserAbstract):
                 logger.info('PROJECT EXECUTION SUCCESSFUL')
                 return  # exit: tests finished
 
-            if ZEPHYR_FATAL_ERROR in line:
+            if ZEPHYR_FATAL_ERROR in line and self.fail_on_fault:
                 logger.error('ZEPHYR FATAL ERROR')
                 self.state = FAILED
-                if self.fail_on_fault:
-                    raise TwisterFatalError('Zephyr fatal error')
+                raise TwisterFatalError('Zephyr fatal error')
 
             if match := testsuite_name_re_pattern.match(line):
                 test_suite_name = match.group(1)

--- a/src/twister2/log_parser/harness_log_parser.py
+++ b/src/twister2/log_parser/harness_log_parser.py
@@ -18,7 +18,7 @@ ZEPHYR_FATAL_ERROR: str = 'ZEPHYR FATAL ERROR'
 result_re_pattern: re.Pattern = re.compile(
     r'^.*(?P<result>PASS|FAIL|SKIP) - (test_)?(?P<testname>.*) in (?P<duration>[\d\.]+) seconds$'
 )
-testsuite_name_re_pattern: re.Pattern = re.compile(r'^.*Running test suite\s(?P<testsuite>.*)$')
+testsuite_name_re_pattern: re.Pattern = re.compile(r'^.*Running TESTSUITE\s(?P<testsuite>.*)$')
 
 logger = logging.getLogger(__name__)
 

--- a/tests/log_parser/data/device_log.txt
+++ b/tests/log_parser/data/device_log.txt
@@ -1,6 +1,6 @@
 ***** delaying boot 500ms (per build configuration) *****
 *** Booting Zephyr OS build zephyr-v3.0.0-2155-g4e9d9f2ef7a1  (delayed boot 500ms) ***
-Running test suite common
+Running TESTSUITE common
 ===================================================================
 START - test_bootdelay
  PASS - test_bootdelay in 0.0 seconds

--- a/tests/log_parser/data/device_log_with_fail.txt
+++ b/tests/log_parser/data/device_log_with_fail.txt
@@ -1,6 +1,6 @@
 ***** delaying boot 500ms (per build configuration) *****
 *** Booting Zephyr OS build zephyr-v3.0.0-2155-g4e9d9f2ef7a1  (delayed boot 500ms) ***
-Running test suite common
+Running TESTSUITE common
 ===================================================================
 START - test_bootdelay
  PASS - test_bootdelay in 0.0 seconds

--- a/tests/log_parser/data/device_log_with_fail_dynamic_thread.txt
+++ b/tests/log_parser/data/device_log_with_fail_dynamic_thread.txt
@@ -1,0 +1,42 @@
+*** Booting Zephyr OS build zephyr-v3.1.0-4682-g8563744997a0  ***
+Running TESTSUITE thread_dynamic
+===================================================================
+START - test_dyn_thread_perms
+E: thread 0x20001664 (3) does not have permission on k_sem 0x20007edc
+E: permission bitmap
+E: 03 00                   |..
+E: syscall z_vrfy_k_sem_give failed check: access denied
+E: r0/a1:  0x00000000  r1/a2:  0x00000000  r2/a3:  0x00000000
+E: r3/a4:  0x00000000 r12/ip:  0x00000000 r14/lr:  0x00000000
+E:  xpsr:  0x00000000
+E: Faulting instruction address (r15/pc): 0xffffffff
+E: >>> ZEPHYR FATAL ERROR 3: Kernel oops on CPU 0
+E: Current thread: 0x20001664 (unknown)
+===== must have access denied on k_sem 0x20007edc
+ PASS - test_dyn_thread_perms in 1.005 seconds
+===================================================================
+START - test_kernel_create_dyn_user_thread
+ PASS - test_kernel_create_dyn_user_thread in 0.001 seconds
+===================================================================
+START - test_thread_index_management
+E: out of free thread indexes
+created 11 thread objects
+ PASS - test_thread_index_management in 0.007 seconds
+===================================================================
+START - test_user_create_dyn_user_thread
+ PASS - test_user_create_dyn_user_thread in 0.001 seconds
+===================================================================
+TESTSUITE thread_dynamic succeeded
+
+------ TESTSUITE SUMMARY START ------
+
+SUITE PASS - 100.00% [thread_dynamic]: pass = 4, fail = 0, skip = 0, total = 4 duration = 1.014 seconds
+ - PASS - [thread_dynamic.test_dyn_thread_perms] duration = 1.005 seconds
+ - PASS - [thread_dynamic.test_kernel_create_dyn_user_thread] duration = 0.001 seconds
+ - PASS - [thread_dynamic.test_thread_index_management] duration = 0.007 seconds
+ - PASS - [thread_dynamic.test_user_create_dyn_user_thread] duration = 0.001 seconds
+
+------ TESTSUITE SUMMARY END ------
+
+===================================================================
+PROJECT EXECUTION SUCCESSFUL

--- a/tests/log_parser/log_parser_test.py
+++ b/tests/log_parser/log_parser_test.py
@@ -28,12 +28,11 @@ def test_if_harness_log_parser_fails_on_fault():
 
 
 def test_if_harness_log_parser_not_fails_on_fault():
-    with open(DATA_DIR / 'device_log_with_fail.txt', 'r', encoding='UTF-8') as file:
+    with open(DATA_DIR / 'device_log_with_fail_dynamic_thread.txt', 'r', encoding='UTF-8') as file:
         stream = (line for line in file)
         parser = HarnessLogParser(stream=stream, fail_on_fault=False)
         sub_tests = list(parser.parse())
-        assert len(sub_tests) == 41
-        assert parser.state == 'FAILED'
-        assert parser.detected_suite_names == ['common']
-        assert len([tc for tc in sub_tests if tc.result == SubTestStatus.SKIP]) == 2
-        assert len([tc for tc in sub_tests if tc.result == SubTestStatus.FAIL]) == 1
+        assert len(sub_tests) == 4
+        assert parser.state == 'PASSED'
+        assert parser.detected_suite_names == ['thread_dynamic']
+        assert len([tc for tc in sub_tests if tc.result == SubTestStatus.PASS]) == 4


### PR DESCRIPTION
When test has tag "ignore_faults", then it should ignore in output error message like "ZEPHYR FATAL ERROR".

As an example of such a test it can be used this one: `tests/kernel/threads/dynamic_thread`. Output from this test is as following:
```
...
===================================================================
START - test_dyn_thread_perms
E: thread 0x20001664 (3) does not have permission on k_sem 0x20007edc
E: permission bitmap
E: 03 00                   |..
E: syscall z_vrfy_k_sem_give failed check: access denied
E: r0/a1:  0x00000000  r1/a2:  0x00000000  r2/a3:  0x00000000
E: r3/a4:  0x00000000 r12/ip:  0x00000000 r14/lr:  0x00000000
E:  xpsr:  0x00000000
E: Faulting instruction address (r15/pc): 0xffffffff
E: >>> ZEPHYR FATAL ERROR 3: Kernel oops on CPU 0
E: Current thread: 0x20001664 (unknown)
===== must have access denied on k_sem 0x20007edc
 PASS - test_dyn_thread_perms in 1.005 seconds
===================================================================
...
```

In test source code it can be found information that this `ZEPHYR FATAL ERROR` is expected:
https://github.com/zephyrproject-rtos/zephyr/blob/main/tests/kernel/threads/dynamic_thread/src/main.c#L87-L90
and test defined in yaml file has tag `ignore_faults`:
https://github.com/zephyrproject-rtos/zephyr/blob/main/tests/kernel/threads/dynamic_thread/testcase.yaml#L3

So, in result this test should be marked as pass.


Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>