### PR TITLE
Fix preparing extra args for west builder

### DIFF
--- a/src/twister2/builder/builder_abstract.py
+++ b/src/twister2/builder/builder_abstract.py
@@ -13,6 +13,10 @@ class BuilderAbstract(abc.ABC):
     """Base class for builders."""
 
     def __init__(self, zephyr_base: str | Path, source_dir: str | Path):
+        """
+        :param zephyr_base: path to zephyr directory
+        :param source_dir: path to test source directory
+        """
         self.zephyr_base: Path = Path(zephyr_base)
         self.source_dir: Path = Path(source_dir)
 

--- a/src/twister2/builder/west.py
+++ b/src/twister2/builder/west.py
@@ -58,4 +58,6 @@ class WestBuilder(BuilderAbstract):
     @staticmethod
     def _prepare_cmake_args(cmake_args: list[str]) -> str:
         args_joined = ' '.join([f'-D{arg}' for arg in cmake_args])
-        return f'"{args_joined}"'
+        if ' ' in args_joined:
+            return f'"{args_joined}"'
+        return f'{args_joined}'

--- a/tests/builder/west_test.py
+++ b/tests/builder/west_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from twister2.builder.west import WestBuilder
+
+
+@pytest.fixture(name='west_builder')
+def fixture_west_builder():
+    """Return west builder"""
+    return WestBuilder(zephyr_base='zephyr', source_dir='source')
+
+
+def test_prepare_cmake_args_with_no_args(west_builder: WestBuilder):
+    cmake_args = []
+    assert west_builder._prepare_cmake_args(cmake_args=cmake_args) == ''
+
+
+def test_prepare_cmake_args_with_one_arg(west_builder: WestBuilder):
+    cmake_args = ['FORKS=FIFOS']
+    assert west_builder._prepare_cmake_args(cmake_args=cmake_args) == '-DFORKS=FIFOS'
+
+
+def test_prepare_cmake_args_with_two_args(west_builder: WestBuilder):
+    cmake_args = ['FORKS=FIFOS', 'CONF_FILE=prj_single.conf']
+    assert west_builder._prepare_cmake_args(cmake_args=cmake_args) == '"-DFORKS=FIFOS -DCONF_FILE=prj_single.conf"'


### PR DESCRIPTION
This PR fixes a build error when there is more than one extra argument passing to west builder.