### PR TITLE
log_parser: change default parser state

### DIFF
--- a/src/twister2/log_parser/log_parser_abstract.py
+++ b/src/twister2/log_parser/log_parser_abstract.py
@@ -6,11 +6,18 @@ from dataclasses import dataclass
 from typing import Generator, Iterator
 
 
+class LogParserState(str, enum.Enum):
+    UNKNOWN = "UNKNOWN"
+    FAILED = "FAILED"
+    PASSED = "PASSED"
+
+
 class LogParserAbstract(abc.ABC):
+    STATE = LogParserState
 
     def __init__(self, stream: Iterator[str], **kwargs):
         self.stream = stream
-        self.state: str = 'PASSED'  #: overall status for execution suite
+        self.state: self.STATE = self.STATE.UNKNOWN  #: overall state for execution test suite
         self.messages: list[str] = []  #: keeps errors from execution
 
     def __repr__(self):

--- a/src/twister2/log_parser/ztest_log_parser.py
+++ b/src/twister2/log_parser/ztest_log_parser.py
@@ -22,9 +22,6 @@ testsuite_name_re_pattern: re.Pattern = re.compile(r'^.*Running TESTSUITE\s(?P<t
 
 logger = logging.getLogger(__name__)
 
-FAILED: str = 'FAILED'
-PASSED: str = 'PASSED'
-
 
 class ZtestLogParser(LogParserAbstract):
     """Parse Ztest output from log stream."""
@@ -53,18 +50,18 @@ class ZtestLogParser(LogParserAbstract):
             logger.debug(line.rstrip())
             if PROJECT_EXECUTION_FAILED in line:
                 logger.error('PROJECT EXECUTION FAILED')
-                self.state = FAILED
+                self.state = self.STATE.FAILED
                 self.messages.append('Project execution failed')
                 return  # exit: tests finished
 
             if PROJECT_EXECUTION_SUCCESSFUL in line:
-                self.state = FAILED if self.state == FAILED else PASSED
+                self.state = self.STATE.FAILED if self.state == self.STATE.FAILED else self.STATE.PASSED
                 logger.info('PROJECT EXECUTION SUCCESSFUL')
                 return  # exit: tests finished
 
             if ZEPHYR_FATAL_ERROR in line and self.fail_on_fault:
                 logger.error('ZEPHYR FATAL ERROR')
-                self.state = FAILED
+                self.state = self.STATE.FAILED
                 raise TwisterFatalError('Zephyr fatal error')
 
             if match := testsuite_name_re_pattern.match(line):

--- a/src/twister2/yaml_test_function.py
+++ b/src/twister2/yaml_test_function.py
@@ -82,4 +82,5 @@ class YamlTestCase:
 
                 assert test.result == SubTestStatus.PASS, f'Subtest {test.testname} failed'
 
-        assert log_parser.state == 'PASSED', 'Test failed due to: {}'.format('\n'.join(log_parser.messages))
+        failed_msg: str = 'Test failed due to: {}'.format('\n'.join(log_parser.messages))
+        assert log_parser.state == log_parser.STATE.PASSED, failed_msg

--- a/tests/log_parser/ztest_log_parser_test.py
+++ b/tests/log_parser/ztest_log_parser_test.py
@@ -11,7 +11,7 @@ def test_if_ztest_log_parser_returns_correct_status(resources: Path):
         parser = ZtestLogParser(stream=file, fail_on_fault=False)
         sub_tests = list(parser.parse())
         assert len(sub_tests) == 45
-        assert parser.state == 'PASSED'
+        assert parser.state == parser.STATE.PASSED
         assert parser.detected_suite_names == ['common']
         assert len([tc for tc in sub_tests if tc.result == SubTestStatus.SKIP]) == 3
         assert len([tc for tc in sub_tests if tc.result == SubTestStatus.FAIL]) == 0
@@ -27,7 +27,7 @@ def test_if_ztest_log_parser_returns_correct_status_with_no_subtests():
     parser = ZtestLogParser(stream=iter(log), fail_on_fault=False)
     sub_tests = list(parser.parse())
     assert len(sub_tests) == 0
-    assert parser.state == 'PASSED'
+    assert parser.state == parser.STATE.PASSED
 
 
 def test_if_ztest_log_parser_returns_correct_status_for_all_tests_skipped():
@@ -44,7 +44,7 @@ def test_if_ztest_log_parser_returns_correct_status_for_all_tests_skipped():
     parser = ZtestLogParser(stream=iter(log), fail_on_fault=False)
     sub_tests = list(parser.parse())
     assert len(sub_tests) == 1
-    assert parser.state == 'PASSED'
+    assert parser.state == parser.STATE.PASSED
     assert len([tc for tc in sub_tests if tc.result == SubTestStatus.SKIP]) == 1
 
 
@@ -58,9 +58,17 @@ def test_if_ztest_log_parser_returns_correct_status_when_subtest_failed():
     """.split('\n')
     parser = ZtestLogParser(stream=iter(log), fail_on_fault=False)
     sub_tests = list(parser.parse())
-    assert parser.state == 'FAILED'
+    assert parser.state == parser.STATE.FAILED
     assert len(sub_tests) == 1
     assert len([tc for tc in sub_tests if tc.result == SubTestStatus.FAIL]) == 1
+
+
+def test_if_ztest_log_parser_returns_correct_status_with_no_input():
+    log = []
+    parser = ZtestLogParser(stream=iter(log), fail_on_fault=False)
+    sub_tests = list(parser.parse())
+    assert len(sub_tests) == 0
+    assert parser.state == parser.STATE.UNKNOWN
 
 
 def test_if_ztest_log_parser_fails_on_fault(resources: Path):
@@ -76,7 +84,7 @@ def test_if_ztest_log_parser_not_fails_on_fault(resources: Path):
         parser = ZtestLogParser(stream=stream, fail_on_fault=False)
         sub_tests = list(parser.parse())
         assert len(sub_tests) == 4
-        assert parser.state == 'PASSED'
+        assert parser.state == parser.STATE.PASSED
         assert parser.detected_suite_names == ['thread_dynamic']
         assert len([tc for tc in sub_tests if tc.result == SubTestStatus.PASS]) == 4
 


### PR DESCRIPTION
Some damaged tests ends without any printed output and in this situation Twister should mark this test as failed. Using default parser state as "PASSED" is risky and can lead to some false negatives cases in the future.

Suitable test for this case was added.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>