### PR TITLE
Add specification from yaml to pytest tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+filelock
 marshmallow
+pyserial
 pytest>=7.0.0
 pytest-cov
 pytest-subtests
 pyyaml
-pyserial

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ packages = find:
 package_dir =
     =src
 install_requires =
+    filelock
     marshmallow
     pytest>=7.0.0
     pytest-subtests>=0.7.0

--- a/src/twister2/builder/build_manager.py
+++ b/src/twister2/builder/build_manager.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from enum import Enum
+from pathlib import Path
+
+from filelock import FileLock
+
+from twister2.builder.builder_abstract import BuildConfig, BuilderAbstract
+from twister2.exceptions import TwisterBuildException
+
+_TMP_DIR: str = tempfile.gettempdir()
+BUILD_STATUS_FILE_NAME: str = 'twister_builder.json'
+BUILD_LOCK_FILE_PATH: str = os.path.join(_TMP_DIR, 'twister_builder.lock')
+
+logger = logging.getLogger(__name__)
+
+
+class BuildStatus(str, Enum):
+    NOT_DONE = 'NOT_DONE'
+    IN_PROGRESS = 'IN_PROGRESS'
+    DONE = 'DONE'
+    FAILED = 'FAILED'
+
+
+class BuildManager:
+    """
+    Class handles information about already built sources.
+
+    It allows to skip building when it was already built for another test.
+    """
+    _lock: FileLock = FileLock(BUILD_LOCK_FILE_PATH, timeout=1)
+
+    def __init__(self, output_dir: str | Path, wait_build_timeout: int = 600) -> None:
+        self._status_file: Path = Path(output_dir) / BUILD_STATUS_FILE_NAME
+        self.wait_build_timeout: int = wait_build_timeout  # seconds
+        self.initialize()
+
+    def initialize(self):
+        with self._lock:
+            if self._status_file.exists():
+                return
+            logger.info('Create empty builder status file: %s', self._status_file)
+            self._write_data({})
+
+    def get_status(self, build_dir: str) -> str:
+        """
+        Return status for build source.
+
+        :param build_dir: path to build director
+        :return: build status
+        """
+        with self._lock:
+            data = self._read_data()
+            return data.get(str(build_dir), BuildStatus.NOT_DONE)
+
+    def _read_data(self):
+        with self._status_file.open(encoding='UTF-8') as file:
+            data: dict = json.load(file)
+        return data
+
+    def update_status(self, build_dir: str, status: str) -> bool:
+        """
+        Update status for build source.
+
+        If new status is equal to old one than return False,
+        otherwise return True
+
+        :param build_dir: path to build director
+        :param status: new status
+        :return: True if status was updated otherwise return False
+        """
+        with self._lock:
+            data = self._read_data()
+            if data.get(build_dir) == status:
+                return False
+            data[str(build_dir)] = status
+            self._write_data(data)
+            return True
+
+    def _write_data(self, data) -> None:
+        with self._status_file.open('w', encoding='UTF-8') as file:
+            json.dump(data, file, indent=2)
+
+    def build(self, builder: BuilderAbstract, build_config: BuildConfig) -> None:
+        """
+        Build source code.
+
+        :param builder: instance of a builder class
+        :param build_config: build configuration
+        """
+        status = self.get_status(build_config.build_dir)
+        if status == BuildStatus.DONE:
+            logger.info('Already build in %s', build_config.build_dir)
+            return
+        if status == BuildStatus.NOT_DONE:
+            if self.update_status(build_config.build_dir, BuildStatus.IN_PROGRESS):
+                self._build(builder=builder, build_config=build_config)
+                return
+            else:
+                status = self.get_status(build_config.build_dir)
+        if status == BuildStatus.IN_PROGRESS:
+            # another builder is building the same source
+            self._wait_for_build_to_finish(build_config.build_dir)
+            status = self.get_status(build_config.build_dir)
+        if status == BuildStatus.FAILED:
+            msg = f'Found in {self._status_file} the build status is set as {BuildStatus.FAILED} ' \
+                  f'for: {build_config.build_dir}'
+            logger.error(msg)
+            raise TwisterBuildException(msg)
+
+    def _build(self, builder: BuilderAbstract, build_config: BuildConfig) -> None:
+        try:
+            builder.build(build_config)
+        except Exception:
+            self.update_status(build_config.build_dir, BuildStatus.FAILED)
+            raise
+        else:
+            self.update_status(build_config.build_dir, BuildStatus.DONE)
+
+    def _wait_for_build_to_finish(self, build_dir: str) -> None:
+        logger.debug('Waiting for finishing building: %s', build_dir)
+        timeout = time.time() + self.wait_build_timeout
+        while self.get_status(build_dir) == BuildStatus.IN_PROGRESS:
+            time.sleep(1)
+            if time.time() > timeout:
+                msg = f'Timed out waiting for another thread to finish building: {build_dir}'
+                logger.error(msg)
+                raise TwisterBuildException(msg)

--- a/src/twister2/builder/builder_abstract.py
+++ b/src/twister2/builder/builder_abstract.py
@@ -2,32 +2,32 @@ from __future__ import annotations
 
 import abc
 import logging
-import os
+from dataclasses import dataclass, field
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class BuildConfig:
+    zephyr_base: str | Path
+    source_dir: str | Path
+    build_dir: str | Path
+    platform: str
+    scenario: str
+    extra_args: list[str] = field(default_factory=list)
+
+
 class BuilderAbstract(abc.ABC):
     """Base class for builders."""
 
-    def __init__(self, zephyr_base: str | Path, source_dir: str | Path):
-        """
-        :param zephyr_base: path to zephyr directory
-        :param source_dir: path to test source directory
-        """
-        self.zephyr_base: Path = Path(zephyr_base)
-        self.source_dir: Path = Path(source_dir)
-
     def __repr__(self):
-        return f'{self.__class__.__name__}(zephyr_base={self.zephyr_base!r}, source_dir={self.source_dir!r})'
-
-    @property
-    def env(self) -> dict[str, str]:
-        env = os.environ.copy()
-        env['ZEPHYR_BASE'] = str(self.zephyr_base)
-        return env
+        return f'{self.__class__.__name__}()'
 
     @abc.abstractmethod
-    def build(self, platform: str, scenario: str, build_dir: str | Path | None = None, **kwargs) -> None:
-        """Build Zephyr application."""
+    def build(self, build_config: BuildConfig) -> None:
+        """
+        Build Zephyr application.
+
+        :param build_config: build configuration
+        """

--- a/src/twister2/builder/factory.py
+++ b/src/twister2/builder/factory.py
@@ -19,15 +19,15 @@ class BuilderFactory:
             cls._builders[name] = klass
 
     @classmethod
-    def get_builder(cls, name: str) -> Type[BuilderAbstract]:
+    def get_builder(cls, name: str) -> BuilderAbstract:
         """
-        Return builder class.
+        Return builder.
 
         :param name: builder name
-        :return: builder class
+        :return: builder instance
         """
         try:
-            return cls._builders[name]
+            return cls._builders[name]()
         except KeyError as e:
             logger.exception('There is not builder with name: %s', name)
             raise KeyError(f'Builder "{name}" does not exist') from e

--- a/src/twister2/fixtures/builder.py
+++ b/src/twister2/fixtures/builder.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 import pytest
 
-from twister2.builder.builder_abstract import BuilderAbstract
+from twister2.builder.build_manager import BuildManager
+from twister2.builder.builder_abstract import BuildConfig, BuilderAbstract
 from twister2.builder.factory import BuilderFactory
+from twister2.exceptions import TwisterConfigurationException
 from twister2.twister_config import TwisterConfig
 
 logger = logging.getLogger(__name__)
@@ -17,16 +19,24 @@ logger = logging.getLogger(__name__)
 def builder(request: pytest.FixtureRequest) -> BuilderAbstract:
     """Build hex files for test suite."""
     twister_config: TwisterConfig = request.config.twister_config
-    function = request.function
-    builder_klass = BuilderFactory.get_builder('west')
-    builder = builder_klass(zephyr_base=twister_config.zephyr_base, source_dir=function.spec.path)
-    function.spec.build_dir = (Path(twister_config.output_dir) / function.spec.platform
-                               / function.spec.rel_to_base_path / function.spec.original_name)
-    function.spec.build_dir = function.spec.build_dir.resolve()
-    builder.build(
-        platform=function.spec.platform,
-        build_dir=function.spec.build_dir,
-        scenario=function.spec.original_name,
-        cmake_args=function.spec.extra_args,
+    spec = request.session.specifications.get(request.node.nodeid)
+    if not spec:
+        msg = f'Could not find test specification for test {request.node.nodeid}'
+        logger.error(msg)
+        raise TwisterConfigurationException(msg)
+
+    spec.output_dir = Path(twister_config.output_dir).resolve()
+
+    builder_type: str = request.config.option.builder
+    builder = BuilderFactory.get_builder(builder_type)
+    build_config = BuildConfig(
+        zephyr_base=twister_config.zephyr_base,
+        source_dir=spec.source_dir,
+        platform=spec.platform,
+        build_dir=spec.build_dir,
+        scenario=spec.scenario,
+        extra_args=spec.extra_args
     )
+    build_manager = BuildManager(request.config.option.output_dir)
+    build_manager.build(builder, build_config)
     yield builder

--- a/src/twister2/fixtures/dut.py
+++ b/src/twister2/fixtures/dut.py
@@ -6,6 +6,7 @@ import pytest
 from twister2.builder.builder_abstract import BuilderAbstract
 from twister2.device.device_abstract import DeviceAbstract
 from twister2.device.factory import DeviceFactory
+from twister2.exceptions import TwisterConfigurationException
 from twister2.twister_config import TwisterConfig
 
 logger = logging.getLogger(__name__)
@@ -15,10 +16,15 @@ logger = logging.getLogger(__name__)
 def dut(request: pytest.FixtureRequest, builder: BuilderAbstract) -> DeviceAbstract:
     """Return device instance."""
     twister_config: TwisterConfig = request.config.twister_config
-    function = request.function
-    build_dir = function.spec.build_dir
+    spec = request.session.specifications.get(request.node.nodeid)
+    if not spec:
+        msg = f'Could not find test specification for test {request.node.nodeid}'
+        logger.error(msg)
+        raise TwisterConfigurationException(msg)
 
-    platform = twister_config.get_platform(request.function.spec.platform)
+    build_dir = spec.build_dir
+
+    platform = twister_config.get_platform(spec.platform)
 
     # TODO: implement
     if twister_config.device_testing:
@@ -26,18 +32,20 @@ def dut(request: pytest.FixtureRequest, builder: BuilderAbstract) -> DeviceAbstr
     elif platform.type == 'native':
         device_type = 'native'
     else:
-        device_type = None
+        msg = f'Handling of device type {platform.type} not implemented yet.'
+        logger.error(msg)
+        pytest.fail(msg)
 
     device_class: Type[DeviceAbstract] = DeviceFactory.get_device(device_type)
     device = device_class(
         twister_config=twister_config,
-        hardware_map=twister_config.get_hardware_map(platform=function.spec.platform)
+        hardware_map=twister_config.get_hardware_map(platform=spec.platform)
     )
 
     if not twister_config.build_only:
         device.connect()
-        device.flash(build_dir=build_dir, timeout=function.spec.timeout)
-        device.run(build_dir=build_dir, timeout=function.spec.timeout)
+        device.flash(build_dir=build_dir, timeout=spec.timeout)
+        device.run(build_dir=build_dir, timeout=spec.timeout)
     yield device
     if not twister_config.build_only:
         device.disconnect()

--- a/src/twister2/generate_tests_plugin.py
+++ b/src/twister2/generate_tests_plugin.py
@@ -1,0 +1,157 @@
+"""
+Plugin generates variants of tests bases on specification from YAML file.
+Test variants are generated for `platform` and `scenario`.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from twister2.exceptions import TwisterConfigurationException
+from twister2.helper import safe_load_yaml
+from twister2.platform_specification import PlatformSpecification
+from twister2.yaml_file import extract_tests, should_be_skip
+from twister2.yaml_test_function import add_markers_from_specification
+from twister2.yaml_test_specification import YamlTestSpecification
+
+TEST_SPEC_FILE_NAME = 'testspec.yaml'
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Variant:
+    """Keeps information about single test variant"""
+    platform: PlatformSpecification
+    scenario: str
+
+    def __str__(self):
+        return f'{self.platform.identifier}:{self.scenario}'
+
+
+def get_scenarios_from_fixture(metafunc: pytest.Metafunc) -> list[str]:
+    """Return scenarios selected by fixture `build_specification`."""
+    if mark := metafunc.definition.get_closest_marker('build_specification'):
+        scenarios = list(mark.args)
+        if not scenarios:
+            logger.warning(
+                'At least one `scenario` should be added to `build_specification` decorator in test: %s',
+                metafunc.definition.nodeid
+            )
+        return scenarios
+    return []
+
+
+def get_scenarios_from_yaml(spec_file: Path) -> list[str]:
+    """Return all available scenarios from yaml specification."""
+    data = safe_load_yaml(spec_file)
+    try:
+        return data['tests'].keys()
+    except KeyError:
+        return []
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc):
+    # generate parametrized tests for each selected platform for ordinary pytest tests
+    # if `specification` fixture is used
+    if 'specification' not in metafunc.fixturenames:
+        return
+
+    twister_config = metafunc.config.twister_config
+
+    platforms_list: list[PlatformSpecification] = [
+        platform for platform in twister_config.platforms
+        if platform.identifier in twister_config.default_platforms
+    ]
+    spec_file_path: Path = Path(metafunc.definition.fspath.dirname) / TEST_SPEC_FILE_NAME
+    scenarios = get_scenarios_from_fixture(metafunc)
+    assert spec_file_path.exists(), f'There is no specification file for the test: {spec_file_path}'
+    if not scenarios:
+        scenarios = get_scenarios_from_yaml(spec_file_path)
+    variants = itertools.product(platforms_list, scenarios)
+    params: list[pytest.param] = []
+    for variant in variants:
+        v = Variant(*variant)
+        params.append(
+            pytest.param(v, marks=pytest.mark.platform(v.platform.identifier), id=str(v))
+        )
+
+    # using indirect=True to inject value from `specification` fixture instead of param
+    metafunc.parametrize(
+        'specification', params, scope='function', indirect=True
+    )
+
+
+@pytest.fixture(scope='function')
+def specification() -> None:
+    """Injects a test specification from yaml file to a test item"""
+    # The body of this function is empty because it is only used to
+    # inform pytest that we want to generate parametrized tests for
+    # a test function which uses this fixture
+
+
+def pytest_configure(config: pytest.Config):
+    config.addinivalue_line(
+        'markers', 'build_specification(names="scenario1,scenario2"): select scenarios to build'
+    )
+
+
+def generate_yaml_test_specification_for_item(item: pytest.Item, variant: Variant) -> YamlTestSpecification:
+    """Add test specification from yaml file to test item."""
+    logger.debug('Adding test specification to item "%s"', item.nodeid)
+    scenario: str = variant.scenario
+    platform: PlatformSpecification = variant.platform
+
+    spec_path: Path = item.path.parent.joinpath(TEST_SPEC_FILE_NAME)
+    assert spec_path.exists(), f'Spec file does not exist: {spec_path}'
+    test_directory_path: Path = item.path.parent
+    rootpath: Path = item.config.rootpath
+
+    raw_spec: dict = safe_load_yaml(spec_path)
+    tests: dict = extract_tests(raw_spec)
+
+    try:
+        test_spec_dict = tests[scenario]
+    except KeyError:
+        msg = f'There is no specification for {scenario} in file {spec_path}'
+        logger.error(msg)
+        raise TwisterConfigurationException(msg)
+
+    test_spec_dict['name'] = item.name
+    test_spec_dict['original_name'] = item.originalname
+    test_spec_dict['source_dir'] = test_directory_path
+    test_spec_dict['platform'] = platform.identifier
+    test_spec_dict['build_name'] = scenario
+    test_spec_dict['rel_to_base_path'] = Path.relative_to(test_spec_dict['source_dir'], rootpath)
+
+    test_spec = YamlTestSpecification(**test_spec_dict)
+
+    add_markers_from_specification(item, test_spec)
+    if should_be_skip(test_spec, platform):
+        item.add_marker(pytest.mark.skip('Does not match requirements'))
+
+    return test_spec
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
+):
+    if not hasattr(session, 'specifications'):
+        session.specifications = {}
+
+    for item in items:
+        # add YAML test specification to session for consistency with python tests
+        if hasattr(item.function, 'spec') and item.nodeid not in session.specifications:
+            session.specifications[item.nodeid] = item.function.spec
+        # yaml test function has no `callspec`
+        if not hasattr(item, 'callspec'):
+            continue
+        if variant := item.callspec.params.get('specification'):
+            spec = generate_yaml_test_specification_for_item(item, variant)
+            session.specifications[item.nodeid] = spec

--- a/src/twister2/helper.py
+++ b/src/twister2/helper.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 import logging
 import platform
 import shlex
+from pathlib import Path
+
+import yaml.parser
+
+from twister2.exceptions import TwisterException
 
 _WINDOWS = (platform.system() == 'Windows')
+
+logger = logging.getLogger(__name__)
 
 
 def string_to_set(value: str | set) -> set[str]:
@@ -19,6 +26,24 @@ def string_to_list(value: str | list) -> list[str]:
         return list(value.split())
     else:
         return value
+
+
+def safe_load_yaml(filename: Path) -> dict:
+    """
+    Return data from yaml file.
+
+    :param filename: path to yaml file
+    :return: data read from yaml file
+    """
+    __tracebackhide__ = True
+    with filename.open(encoding='UTF-8') as file:
+        try:
+            data = yaml.safe_load(file)
+        except yaml.parser.ParserError as exc:
+            logger.error('Parsing error for yaml file %s: %s', filename, exc)
+            raise TwisterException(f'Cannot load data from yaml file: {filename}')
+        else:
+            return data
 
 
 def log_command(logger: logging.Logger, msg: str, args: list, level: int = logging.DEBUG):

--- a/src/twister2/platform_specification.py
+++ b/src/twister2/platform_specification.py
@@ -6,11 +6,10 @@ from pathlib import Path
 from typing import Generator
 
 import pytest
-import yaml
 from marshmallow import Schema, fields, validate
 
 from twister2.exceptions import TwisterConfigurationException
-from twister2.helper import string_to_set
+from twister2.helper import safe_load_yaml, string_to_set
 
 logger = logging.getLogger(__name__)
 
@@ -57,13 +56,12 @@ class PlatformSpecification:
     @classmethod
     def load_from_yaml(cls, filename: str | Path) -> PlatformSpecification:
         """Load platform from yaml file."""
-        with open(filename, 'r', encoding='UTF-8') as file:
-            data: dict = yaml.safe_load(file)
+        data: dict = safe_load_yaml(Path(filename))
         try:
             data = PlatformSchema().load(data)
             return cls.from_dict(data)
         except Exception as e:
-            logger.exception('Cannot create PlatformSpecification from yaml data: %s', data)
+            logger.error('Cannot create PlatformSpecification from yaml data: %s', data)
             raise TwisterConfigurationException('Cannot create PlatformSpecification from yaml data') from e
 
     @classmethod
@@ -117,7 +115,7 @@ def discover_platforms(directory: Path) -> Generator[PlatformSpecification, None
         try:
             yield PlatformSpecification.load_from_yaml(str(file))
         except Exception as e:
-            logger.exception('Cannot read platform definition from yaml: %e', e)
+            logger.exception('Cannot read platform definition from yaml: %s', e)
             raise
 
 

--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -30,6 +30,7 @@ pytest_plugins = (
     'twister2.fixtures.builder',
     'twister2.fixtures.dut',
     'twister2.fixtures.log_parser',
+    'twister2.generate_tests_plugin',
 )
 
 

--- a/src/twister2/yaml_test_function.py
+++ b/src/twister2/yaml_test_function.py
@@ -28,15 +28,28 @@ def yaml_test_function_factory(spec: YamlTestSpecification, parent: Any) -> Yaml
         parent=parent,
         callobj=YamlTestCase(spec),  # callable object (test function)
     )
-    function.add_marker(pytest.mark.platform(spec.platform))
-    function.add_marker(pytest.mark.type(spec.type))
-    if spec.tags:
-        function.add_marker(pytest.mark.tags(*spec.tags))
-    if spec.slow:
-        function.add_marker(pytest.mark.slow)
-    if spec.skip:
-        function.add_marker(pytest.mark.skip('Skipped in yaml specification'))
+    add_markers_from_specification(function, spec)
     return function
+
+
+def add_markers_from_specification(obj: pytest.Item | pytest.Function, spec: YamlTestSpecification) -> None:
+    """
+    Add markers to pytest function or item.
+
+    Function adds all required markers base on test specification.
+
+    :param obj: instance of pytest Item or Function
+    :param spec: yaml test specification
+    """
+    obj.add_marker(pytest.mark.platform(spec.platform))
+    if spec.type:
+        obj.add_marker(pytest.mark.type(spec.type))
+    if spec.tags:
+        obj.add_marker(pytest.mark.tags(*spec.tags))
+    if spec.slow:
+        obj.add_marker(pytest.mark.slow)
+    if spec.skip:
+        obj.add_marker(pytest.mark.skip('Skipped in yaml specification'))
 
 
 class YamlTestFunction(pytest.Function):
@@ -66,7 +79,7 @@ class YamlTestCase:
             # do not run test for build only
             return
 
-        logger.info('Execution test %s from %s', self.spec.name, self.spec.path)
+        logger.info('Execution test %s from %s', self.spec.name, self.spec.source_dir)
 
         log_parser.parse(timeout=self.spec.timeout)
 

--- a/src/twister2/yaml_test_specification.py
+++ b/src/twister2/yaml_test_specification.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 from marshmallow import Schema, ValidationError, fields, validate
 
@@ -18,10 +17,11 @@ class YamlTestSpecification:
     """Test specification for yaml test."""
     name: str  #: test case name plus platform
     original_name: str  #: keeps test case name without platform
-    path: Path  #: path to a folder where C files are stored
+    source_dir: Path  #: path to a folder where C files are stored
     rel_to_base_path: Path  #: path relative to zephyr base
     platform: str  #: platform name used for this test
-    build_dir: Optional[Path] = None  #: path to dir with build results
+    build_name: str = ''  #: name of build configuration from yaml
+    output_dir: Path = Path('.')  #: path to dir with build results
     tags: set[str] = field(default_factory=set)
     type: str = 'integration'
     filter: str = ''
@@ -67,6 +67,16 @@ class YamlTestSpecification:
         self.extra_args = string_to_list(self.extra_args)
         self.integration_platforms = string_to_list(self.integration_platforms)
         self.timeout *= self.timeout_multiplier
+
+    @property
+    def scenario(self):
+        return self.build_name or self.original_name
+
+    @property
+    def build_dir(self) -> Path:
+        return (
+            self.output_dir / self.platform / self.rel_to_base_path / self.scenario
+        )
 
 
 # Using marshmallow to validate specification from yaml

--- a/tests/builder/build_manager_test.py
+++ b/tests/builder/build_manager_test.py
@@ -1,0 +1,131 @@
+import threading
+import time
+from contextlib import contextmanager
+from unittest import mock
+
+import pytest
+
+from twister2.builder.build_manager import BuildManager, BuildStatus
+from twister2.exceptions import TwisterBuildException
+
+BUILD_DIR = 'build'
+
+
+class MockBuilder(mock.Mock):
+    def build(self, build_config):
+        return
+
+
+@pytest.fixture
+def mocked_builder():
+    return MockBuilder()
+
+
+@pytest.fixture
+def build_manager(tmp_path) -> BuildManager:
+    build_manager = BuildManager(tmp_path, wait_build_timeout=2)
+    return build_manager
+
+
+@contextmanager
+def run_job_in_thread(job):
+    # used to simplified test code
+    t = threading.Thread(target=job, daemon=True)
+    t.start()
+    yield
+    t.join()
+
+
+def test_if_status_can_be_updated(build_manager):
+    build_manager.update_status('build_dir_1', BuildStatus.DONE)
+    assert build_manager.get_status('build_dir_1') == BuildStatus.DONE
+
+
+def test_if_status_was_updated_after_build(build_manager, build_config):
+    mocked_builder = MockBuilder()
+    build_manager.update_status(BUILD_DIR, BuildStatus.NOT_DONE)
+
+    build_manager.build(builder=mocked_builder, build_config=build_config)
+    assert build_manager.get_status(BUILD_DIR) == BuildStatus.DONE
+
+
+def test_if_build_manager_is_waiting_for_finish_another_build(build_manager, mocked_builder, build_config, monkeypatch):
+    _wait_for_build_to_finish = mock.MagicMock()
+    monkeypatch.setattr(build_manager, '_wait_for_build_to_finish', _wait_for_build_to_finish)
+    build_manager.update_status(BUILD_DIR, BuildStatus.IN_PROGRESS)
+
+    build_manager.build(builder=mocked_builder, build_config=build_config)
+    assert build_manager.get_status(BUILD_DIR) == BuildStatus.IN_PROGRESS
+    _wait_for_build_to_finish.assert_called_once()
+
+
+def test_if_test_is_failed_when_build_status_was_failed(build_manager, mocked_builder, build_config):
+    build_manager.update_status(BUILD_DIR, BuildStatus.FAILED)
+
+    expected_msg = f'Found in .*twister_builder.json the build status is set as {BuildStatus.FAILED} for: {BUILD_DIR}'
+    with pytest.raises(TwisterBuildException, match=expected_msg):
+        build_manager.build(builder=mocked_builder, build_config=build_config)
+
+
+def test_if_build_manager_does_not_build_when_source_is_already_built(
+        build_manager, mocked_builder, build_config, monkeypatch
+):
+    _wait_for_build_to_finish = mock.MagicMock()
+    _build = mock.MagicMock()
+    monkeypatch.setattr(build_manager, '_wait_for_build_to_finish', _wait_for_build_to_finish)
+    monkeypatch.setattr(build_manager, '_build', _build)
+    build_manager.update_status(BUILD_DIR, BuildStatus.DONE)
+
+    build_manager.build(builder=mocked_builder, build_config=build_config)
+    assert build_manager.get_status(BUILD_DIR) == BuildStatus.DONE
+    _wait_for_build_to_finish.assert_not_called()
+    _build.assert_not_called()
+
+
+def test_if_build_manager_waits_until_status_is_changed_to_done(
+        build_manager, mocked_builder, build_config
+):
+    """
+    Building source code is ongoing by one process.
+    Another process starts building same source code, and because build status is
+    `IN_PROGRESS` second process waits for first process to finish building.
+    While first process finished building second process should leave waiting loop.
+    The build status should be updated by build manager to `DONE`.
+    """
+    build_manager.update_status(BUILD_DIR, BuildStatus.IN_PROGRESS)
+
+    def update_status():
+        time.sleep(0.1)
+        build_manager.update_status(BUILD_DIR, BuildStatus.DONE)
+
+    with run_job_in_thread(update_status):
+        start_time = time.time()
+        build_manager.build(builder=mocked_builder, build_config=build_config)
+        finish_time = time.time()
+    assert build_manager.get_status(BUILD_DIR) == BuildStatus.DONE
+    assert finish_time - start_time < 2  # Should not wait longer than 1 second
+
+
+def test_if_build_manager_waits_until_status_is_changed_to_failed(
+        build_manager, mocked_builder, build_config
+):
+    build_manager.update_status(BUILD_DIR, BuildStatus.IN_PROGRESS)
+
+    def update_status():
+        time.sleep(0.1)
+        build_manager.update_status(BUILD_DIR, BuildStatus.FAILED)
+
+    expected_msg = f'Found in .*twister_builder.json the build status is set as ' \
+                   f'{BuildStatus.FAILED} for: {BUILD_DIR}'
+    with run_job_in_thread(update_status):
+        with pytest.raises(TwisterBuildException, match=expected_msg):
+            build_manager.build(builder=mocked_builder, build_config=build_config)
+    assert build_manager.get_status(BUILD_DIR) == BuildStatus.FAILED
+
+
+def test_if_build_manager_waits_until_timed_out(build_manager, mocked_builder, build_config):
+    build_manager.update_status(BUILD_DIR, BuildStatus.IN_PROGRESS)
+    build_manager.wait_build_timeout = 1
+    expected_msg = f'Timed out waiting for another thread to finish building: {BUILD_DIR}'
+    with pytest.raises(TwisterBuildException, match=expected_msg):
+        build_manager.build(builder=mocked_builder, build_config=build_config)

--- a/tests/builder/conftest.py
+++ b/tests/builder/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+from twister2.builder.builder_abstract import BuildConfig
+
+
+@pytest.fixture(name='build_config')
+def fixture_build_config() -> BuildConfig:
+    return BuildConfig(
+        zephyr_base='zephyr',
+        source_dir='source',
+        build_dir='build',
+        platform='native_posix',
+        scenario='bt',
+        extra_args=['CONFIG_NEWLIB_LIBC=y']
+    )

--- a/tests/yaml_file_test.py
+++ b/tests/yaml_file_test.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 
 import pytest
+
 from twister2.platform_specification import PlatformSpecification
 from twister2.twister_config import TwisterConfig
 from twister2.yaml_file import (
-    _read_test_specifications_from_yaml,
     _join_filters,
     _join_strings,
+    _read_test_specifications_from_yaml,
     should_skip_for_arch,
     should_skip_for_min_flash,
     should_skip_for_min_ram,
@@ -15,7 +16,6 @@ from twister2.yaml_file import (
     should_skip_for_toolchain,
 )
 from twister2.yaml_test_specification import YamlTestSpecification
-
 
 DATA_DIR: Path = Path(__file__).parent / 'data'
 
@@ -27,7 +27,7 @@ def testcase() -> YamlTestSpecification:
         original_name='dummy_test',
         rel_to_base_path=Path('out_of_tree'),
         platform='platform',
-        path=Path('dummy_path')
+        source_dir=Path('dummy_path')
     )
 
 
@@ -39,7 +39,7 @@ def platform() -> PlatformSpecification:
 @pytest.fixture(scope='function')
 def twister_config(platform) -> TwisterConfig:
     return TwisterConfig(
-        zephyr_base="dummy_path",
+        zephyr_base='dummy_path',
         default_platforms=[platform.identifier],
         platforms=[platform]
     )
@@ -182,15 +182,15 @@ def test_if_join_filters_returns_joined_filters_without_empty_strings():
 
 
 def test_read_test_specifications_from_yaml_common(twister_config):
-    yaml_file_path = DATA_DIR / "common" / "testcase.yaml"
+    yaml_file_path = DATA_DIR / 'common' / 'testcase.yaml'
     for spec in _read_test_specifications_from_yaml(yaml_file_path, twister_config):
-        if spec.original_name == "xyz.common_merge_1":
-            assert spec.tags == {"kernel", "posix", "picolibc"}
-            assert spec.extra_configs == ["CONFIG_NEWLIB_LIBC=y", "CONFIG_POSIX_API=y"]
-            assert spec.filter == "(CONFIG_PICOLIBC_SUPPORTED) and (TOOLCHAIN_HAS_NEWLIB == 1)"
+        if spec.original_name == 'xyz.common_merge_1':
+            assert spec.tags == {'kernel', 'posix', 'picolibc'}
+            assert spec.extra_configs == ['CONFIG_NEWLIB_LIBC=y', 'CONFIG_POSIX_API=y']
+            assert spec.filter == '(CONFIG_PICOLIBC_SUPPORTED) and (TOOLCHAIN_HAS_NEWLIB == 1)'
             assert spec.min_ram == 64
-        elif spec.original_name == "xyz.common_merge_2":
-            assert spec.tags == {"kernel", "posix", "arm"}
-            assert spec.extra_configs == ["CONFIG_POSIX_API=y"]
-            assert spec.filter == "TOOLCHAIN_HAS_NEWLIB == 1"
+        elif spec.original_name == 'xyz.common_merge_2':
+            assert spec.tags == {'kernel', 'posix', 'arm'}
+            assert spec.extra_configs == ['CONFIG_POSIX_API=y']
+            assert spec.filter == 'TOOLCHAIN_HAS_NEWLIB == 1'
             assert spec.min_ram == 32

--- a/tests/yaml_test_specification_test.py
+++ b/tests/yaml_test_specification_test.py
@@ -145,7 +145,7 @@ def test_if_can_create_test_specification_instance_from_dict(yaml_specification)
     params = yaml_specification['tests']['test_foo']
     params['name'] = 'test_foo'
     params['original_name'] = 'test_foo'
-    params['path'] = '/tmp'
+    params['source_dir'] = 'src'
     params['rel_to_base_path'] = '/tmp'
     params['platform'] = 'native_posix'
     YamlTestSpecification(**params)


### PR DESCRIPTION
Added an implementation which allows to inject a test specification (same as for twister test) to regular pytest tests. 

Example usage:

Having test implementation like so:
```python
# FILE: hello_world_test.py
# it will generate variants for all available scenarios from yaml file
def test_hello_world(specification, builder, log_parser):
    log_parser.parse(timeout=5)
    assert log_parser.state == 'PASSED'

# it will generate variants for scenario1 and scenario2 only
@pytest.mark.build_specification('scenario1', 'scenario2')
def test_hello_world_2(specification, builder, log_parser):
    log_parser.parse(timeout=5)
    assert log_parser.state == 'PASSED'
```

testspec.yaml:
```yaml
tests:
  scenario1:
    tags: introduction
    timeout: 5
    harness: console
    harness_config:
        type: one_line
        regex:
            - "Hello World! (.*)"
   scenario2:
      tags: tag1
   scenario3:
      tags: tag1
```

and folder structure like so:
```
├── hello_world
     ├── CMakeLists.txt
     ├── hello_world_test.py
     ├── prj.conf
     ├── src
     │   └── main.c
     └── testspec.yaml
```
we can run this test like:
`pytest --platform=native_posix --platform=nrf52840dk_nrf52840`
and get two parametrized tests:
```
<Module tests/hello_world/hello_world_test.py>
  <Function test_hello_world[scenario1:nrf52840dk_nrf52840]>
  <Function test_hello_world[scenario1:native_posix]>
  <Function test_hello_world[scenario2:nrf52840dk_nrf52840]>
  <Function test_hello_world[scenario2:native_posix]>
  <Function test_hello_world[scenario3:nrf52840dk_nrf52840]>
  <Function test_hello_world[scenario3:native_posix]>
  <Function test_hello_world_2[scenario1:nrf52840dk_nrf52840]>
  <Function test_hello_world_2[scenario1:native_posix]>
  <Function test_hello_world_2[scenario2:nrf52840dk_nrf52840]>
  <Function test_hello_world_2[scenario2:native_posix]>
```