### PR TITLE
log_parser: use ignore_fault option

### DIFF
--- a/src/twister2/fixtures/log_parser.py
+++ b/src/twister2/fixtures/log_parser.py
@@ -15,7 +15,7 @@ def log_parser(request: pytest.FixtureRequest, dut) -> ZtestLogParser | None:
     """Return log parser."""
     parser_name = request.function.spec.harness or 'ztest'  # make ztest default parser
     harness_config = request.function.spec.harness_config
-    fail_on_fault = False if 'ignore_faults' in request.function.spec.tags else True
+    ignore_faults = request.function.spec.ignore_faults
 
     parser_class = LogParserFactory.get_parser(parser_name)
-    yield parser_class(stream=dut.iter_stdout, harness_config=harness_config, fail_on_fault=fail_on_fault)
+    yield parser_class(stream=dut.iter_stdout, harness_config=harness_config, ignore_faults=ignore_faults)

--- a/src/twister2/log_parser/ztest_log_parser.py
+++ b/src/twister2/log_parser/ztest_log_parser.py
@@ -26,10 +26,10 @@ logger = logging.getLogger(__name__)
 class ZtestLogParser(LogParserAbstract):
     """Parse Ztest output from log stream."""
 
-    def __init__(self, stream: Iterator[str], *, fail_on_fault: bool = False, **kwargs):
+    def __init__(self, stream: Iterator[str], *, ignore_faults: bool = False, **kwargs):
         super().__init__(stream, **kwargs)
         self.detected_suite_names: list[str] = []
-        self.fail_on_fault = fail_on_fault
+        self.ignore_faults = ignore_faults
 
     def parse(self, timeout: float = 60) -> Generator[SubTestResult, None, None]:
         """Parse logs and return list of tests with statuses."""
@@ -59,7 +59,7 @@ class ZtestLogParser(LogParserAbstract):
                 logger.info('PROJECT EXECUTION SUCCESSFUL')
                 return  # exit: tests finished
 
-            if ZEPHYR_FATAL_ERROR in line and self.fail_on_fault:
+            if ZEPHYR_FATAL_ERROR in line and not self.ignore_faults:
                 logger.error('ZEPHYR FATAL ERROR')
                 self.state = self.STATE.FAILED
                 raise TwisterFatalError('Zephyr fatal error')

--- a/tests/log_parser/ztest_log_parser_test.py
+++ b/tests/log_parser/ztest_log_parser_test.py
@@ -8,7 +8,7 @@ from twister2.log_parser.ztest_log_parser import ZtestLogParser
 
 def test_if_ztest_log_parser_returns_correct_status(resources: Path):
     with open(resources / 'ztest_log.txt', encoding='UTF-8') as file:
-        parser = ZtestLogParser(stream=file, fail_on_fault=False)
+        parser = ZtestLogParser(stream=file, ignore_faults=False)
         sub_tests = list(parser.parse())
         assert len(sub_tests) == 45
         assert parser.state == parser.STATE.PASSED
@@ -24,7 +24,7 @@ def test_if_ztest_log_parser_returns_correct_status_with_no_subtests():
         Running TESTSUITE common
         PROJECT EXECUTION SUCCESSFUL
     """.split('\n')
-    parser = ZtestLogParser(stream=iter(log), fail_on_fault=False)
+    parser = ZtestLogParser(stream=iter(log), ignore_faults=False)
     sub_tests = list(parser.parse())
     assert len(sub_tests) == 0
     assert parser.state == parser.STATE.PASSED
@@ -41,7 +41,7 @@ def test_if_ztest_log_parser_returns_correct_status_for_all_tests_skipped():
          SKIP - test_nop in 0.0 seconds
         PROJECT EXECUTION SUCCESSFUL
     """.split('\n')
-    parser = ZtestLogParser(stream=iter(log), fail_on_fault=False)
+    parser = ZtestLogParser(stream=iter(log), ignore_faults=False)
     sub_tests = list(parser.parse())
     assert len(sub_tests) == 1
     assert parser.state == parser.STATE.PASSED
@@ -56,7 +56,7 @@ def test_if_ztest_log_parser_returns_correct_status_when_subtest_failed():
         FAIL - test_clock_cycle_64 in 0.20 seconds
         PROJECT EXECUTION FAILED
     """.split('\n')
-    parser = ZtestLogParser(stream=iter(log), fail_on_fault=False)
+    parser = ZtestLogParser(stream=iter(log), ignore_faults=False)
     sub_tests = list(parser.parse())
     assert parser.state == parser.STATE.FAILED
     assert len(sub_tests) == 1
@@ -65,7 +65,7 @@ def test_if_ztest_log_parser_returns_correct_status_when_subtest_failed():
 
 def test_if_ztest_log_parser_returns_correct_status_with_no_input():
     log = []
-    parser = ZtestLogParser(stream=iter(log), fail_on_fault=False)
+    parser = ZtestLogParser(stream=iter(log), ignore_faults=False)
     sub_tests = list(parser.parse())
     assert len(sub_tests) == 0
     assert parser.state == parser.STATE.UNKNOWN
@@ -73,7 +73,7 @@ def test_if_ztest_log_parser_returns_correct_status_with_no_input():
 
 def test_if_ztest_log_parser_fails_on_fault(resources: Path):
     with open(resources / 'ztest_log_with_fail.txt', 'r', encoding='UTF-8') as file:
-        parser = ZtestLogParser(stream=file, fail_on_fault=True)
+        parser = ZtestLogParser(stream=file, ignore_faults=False)
         with pytest.raises(TwisterFatalError, match='Zephyr fatal error'):
             list(parser.parse())
 
@@ -81,7 +81,7 @@ def test_if_ztest_log_parser_fails_on_fault(resources: Path):
 def test_if_ztest_log_parser_not_fails_on_fault(resources: Path):
     with open(resources / 'ztest_log_with_fail_dynamic_thread.txt', 'r', encoding='UTF-8') as file:
         stream = (line for line in file)
-        parser = ZtestLogParser(stream=stream, fail_on_fault=False)
+        parser = ZtestLogParser(stream=stream, ignore_faults=True)
         sub_tests = list(parser.parse())
         assert len(sub_tests) == 4
         assert parser.state == parser.STATE.PASSED


### PR DESCRIPTION
Since ingmore_fault option was introduced to yaml test definition, then it should be used instead of tags.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>