### PR TITLE
log_parser: refactor parse method

### DIFF
--- a/src/twister2/fixtures/log_parser.py
+++ b/src/twister2/fixtures/log_parser.py
@@ -3,19 +3,24 @@ from __future__ import annotations
 import logging
 
 import pytest
+from pytest_subtests import SubTests
 
+from twister2.device.device_abstract import DeviceAbstract
 from twister2.log_parser.factory import LogParserFactory
-from twister2.log_parser.ztest_log_parser import ZtestLogParser
+from twister2.log_parser.log_parser_abstract import LogParserAbstract
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
-def log_parser(request: pytest.FixtureRequest, dut) -> ZtestLogParser | None:
+def log_parser(request: pytest.FixtureRequest, dut: DeviceAbstract, subtests: SubTests) -> LogParserAbstract:
     """Return log parser."""
     parser_name = request.function.spec.harness or 'ztest'  # make ztest default parser
     harness_config = request.function.spec.harness_config
     ignore_faults = request.function.spec.ignore_faults
 
     parser_class = LogParserFactory.get_parser(parser_name)
-    yield parser_class(stream=dut.iter_stdout, harness_config=harness_config, ignore_faults=ignore_faults)
+    yield parser_class(stream=dut.iter_stdout,
+                       harness_config=harness_config,
+                       ignore_faults=ignore_faults,
+                       subtests_fixture=subtests)

--- a/src/twister2/log_parser/__init__.py
+++ b/src/twister2/log_parser/__init__.py
@@ -1,2 +1,0 @@
-from .log_parser_abstract import SubTestResult
-from .log_parser_abstract import SubTestStatus

--- a/src/twister2/log_parser/console_log_parser.py
+++ b/src/twister2/log_parser/console_log_parser.py
@@ -9,7 +9,6 @@ import time
 from typing import Callable, Iterator
 
 from twister2.exceptions import TwisterHarnessParserException
-from twister2.log_parser import SubTestResult
 from twister2.log_parser.log_parser_abstract import LogParserAbstract
 
 logger = logging.getLogger(__name__)
@@ -49,7 +48,7 @@ class ConsoleLogParser(LogParserAbstract):
             logger.error('Unknown harness_config type')
             raise TwisterHarnessParserException('Unknown harness_config type')
 
-    def parse(self, timeout: float = 60) -> Iterator[SubTestResult]:
+    def parse(self, timeout: float = 60) -> None:
         logger.debug('%s: Parsing output', self.__class__.__name__)
         end_time = time.time() + timeout
         while self.stream:
@@ -71,8 +70,6 @@ class ConsoleLogParser(LogParserAbstract):
         if len(self.matched_lines) != len(self.regex):
             self.state = self.STATE.FAILED
             self.messages.append('Did not find expected messages')
-
-        return []
 
     def _parse_one_line(self, line: str) -> bool:
         if self.patterns[0].search(line):

--- a/src/twister2/log_parser/log_parser_abstract.py
+++ b/src/twister2/log_parser/log_parser_abstract.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import abc
 import enum
-from dataclasses import dataclass
-from typing import Generator, Iterator
+from typing import Iterator
 
 
 class LogParserState(str, enum.Enum):
-    UNKNOWN = "UNKNOWN"
-    FAILED = "FAILED"
-    PASSED = "PASSED"
+    UNKNOWN = 'UNKNOWN'
+    FAILED = 'FAILED'
+    PASSED = 'PASSED'
 
 
 class LogParserAbstract(abc.ABC):
@@ -24,38 +23,5 @@ class LogParserAbstract(abc.ABC):
         return f'{self.__class__.__name__}()'
 
     @abc.abstractmethod
-    def parse(self, timeout: float = 60) -> Generator[SubTestResult, None, None]:
-        """Return results of subtests."""
-
-
-# TODO: it is ztest related, should be moved to ztest parser
-class SubTestStatus(str, enum.Enum):
-    PASS = 'PASS'
-    FAIL = 'FAIL'
-    SKIP = 'SKIP'
-    BLOCK = 'BLOCK'  # there is no `block` status in pytest, should be handled as skip
-
-    def __str__(self):
-        return self.name
-
-
-@dataclass
-class SubTestResult:
-    """Store result for single C tests."""
-    testname: str
-    result: SubTestStatus
-    duration: float
-
-    def __post_init__(self):
-        if isinstance(self.duration, str):
-            self.duration = float(self.duration)
-        if isinstance(self.result, str):
-            self.result = SubTestStatus(self.result)
-
-    def asdict(self) -> dict:
-        """Return JSON serialized dictionary."""
-        return dict(
-            testname=self.testname,
-            result=str(self.result),
-            duration=self.duration
-        )
+    def parse(self, timeout: float = 60) -> None:
+        """Parse output from device and set appropriate parser status"""

--- a/src/twister2/log_parser/ztest_log_parser.py
+++ b/src/twister2/log_parser/ztest_log_parser.py
@@ -3,13 +3,18 @@ Ztest log parser.
 """
 from __future__ import annotations
 
+import enum
 import logging
 import re
 import time
-from typing import Iterator, Generator
+from dataclasses import dataclass
+from typing import Iterator
+
+import pytest
+from pytest_subtests import SubTests
 
 from twister2.exceptions import TwisterFatalError
-from twister2.log_parser.log_parser_abstract import SubTestResult, LogParserAbstract
+from twister2.log_parser.log_parser_abstract import LogParserAbstract
 
 PROJECT_EXECUTION_SUCCESSFUL: str = 'PROJECT EXECUTION SUCCESSFUL'
 PROJECT_EXECUTION_FAILED: str = 'PROJECT EXECUTION FAILED'
@@ -26,18 +31,25 @@ logger = logging.getLogger(__name__)
 class ZtestLogParser(LogParserAbstract):
     """Parse Ztest output from log stream."""
 
-    def __init__(self, stream: Iterator[str], *, ignore_faults: bool = False, **kwargs):
+    def __init__(self,
+                 stream: Iterator[str],
+                 *,
+                 ignore_faults: bool = False,
+                 subtests_fixture: SubTests | None = None,
+                 **kwargs):
         super().__init__(stream, **kwargs)
+        self.subtests_fixture: SubTests = subtests_fixture
+        self.ignore_faults: bool = ignore_faults
         self.detected_suite_names: list[str] = []
-        self.ignore_faults = ignore_faults
+        self.subtest_results: list[SubTestResult] = []
 
-    def parse(self, timeout: float = 60) -> Generator[SubTestResult, None, None]:
-        """Parse logs and return list of tests with statuses."""
+    def parse(self, timeout: float = 60) -> None:
+        """Parse logs and create list of subtests with statuses."""
         end_time = time.time() + timeout
         while self.stream:
             if time.time() > end_time:
                 self.messages.append('Timeout')
-                break
+                return
 
             try:
                 line = next(self.stream)
@@ -69,7 +81,55 @@ class ZtestLogParser(LogParserAbstract):
                 logger.info('Found test suite: %s', test_suite_name)
                 self.detected_suite_names.append(test_suite_name)
 
-            if match := result_re_pattern.match(line):
-                test = SubTestResult(**match.groupdict())
-                logger.info('Ztest: %s - %s in %s', test.testname, test.result, test.duration)
-                yield test
+            if result_match := result_re_pattern.match(line):
+                subtest = SubTestResult(**result_match.groupdict())
+                self.subtest_results.append(subtest)
+                logger.info('Ztest: %s - %s in %s', subtest.testname, subtest.result, subtest.duration)
+                self._register_pytest_subtests(subtest)
+
+    def _register_pytest_subtests(self, subtest: SubTestResult):
+        '''
+        Using subtests fixture to log single C test
+        https://pypi.org/project/pytest-subtests/
+        '''
+        if self.subtests_fixture is None:
+            return
+
+        with self.subtests_fixture.test(msg=subtest.testname):
+            if subtest.result == SubTestStatus.SKIP:
+                pytest.skip('Skipped on runtime')
+            if subtest.result == SubTestStatus.BLOCK:
+                pytest.skip('Blocked')
+            assert subtest.result == SubTestStatus.PASS, f'Subtest {subtest.testname} failed'
+
+
+class SubTestStatus(str, enum.Enum):
+    PASS = 'PASS'
+    FAIL = 'FAIL'
+    SKIP = 'SKIP'
+    BLOCK = 'BLOCK'  # there is no `block` status in pytest, should be handled as skip
+
+    def __str__(self):
+        return self.name
+
+
+@dataclass
+class SubTestResult:
+    """Store result for single C tests."""
+    testname: str
+    result: SubTestStatus
+    duration: float
+
+    def __post_init__(self):
+        if isinstance(self.duration, str):
+            self.duration = float(self.duration)
+        if isinstance(self.result, str):
+            self.result = SubTestStatus(self.result)
+
+    def asdict(self) -> dict:
+        """Return JSON serialized dictionary."""
+        return dict(
+            testname=self.testname,
+            result=str(self.result),
+            duration=self.duration
+        )

--- a/src/twister2/yaml_test_function.py
+++ b/src/twister2/yaml_test_function.py
@@ -1,7 +1,7 @@
 """
 Yaml test implementation.
 
-Module creates pytest test function representing Zypher C tests.
+Module creates pytest test function representing Zephyr C tests.
 
 Base on pytest non-python test example:
 https://docs.pytest.org/en/6.2.x/example/nonpython.html
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 
 from twister2.device.device_abstract import DeviceAbstract
-from twister2.log_parser.log_parser_abstract import LogParserAbstract, SubTestStatus
+from twister2.log_parser.log_parser_abstract import LogParserAbstract
 from twister2.yaml_test_specification import YamlTestSpecification
 
 logger = logging.getLogger(__name__)
@@ -59,7 +59,6 @@ class YamlTestCase:
         request: pytest.FixtureRequest,
         dut: DeviceAbstract,
         log_parser: LogParserAbstract,
-        subtests,
         *args, **kwargs
     ):
         """Method called by pytest when it runs test."""
@@ -69,18 +68,7 @@ class YamlTestCase:
 
         logger.info('Execution test %s from %s', self.spec.name, self.spec.path)
 
-        # using subtests fixture to log single C test
-        # https://pypi.org/project/pytest-subtests/
-        for test in log_parser.parse(timeout=self.spec.timeout):
-            with subtests.test(msg=test.testname):
-                if test.result == SubTestStatus.SKIP:
-                    pytest.skip('Skipped on runtime')
-                    continue
-                if test.result == SubTestStatus.BLOCK:
-                    pytest.skip('Blocked')
-                    continue
-
-                assert test.result == SubTestStatus.PASS, f'Subtest {test.testname} failed'
+        log_parser.parse(timeout=self.spec.timeout)
 
         if log_parser.state == log_parser.STATE.UNKNOWN:
             failed_msg: str = f'Test state is {log_parser.state.value} (timeout has probably occurred)'

--- a/tests/log_parser/console_log_parser_test.py
+++ b/tests/log_parser/console_log_parser_test.py
@@ -17,7 +17,7 @@ def test_if_console_log_parser_passes_for_one_line_type():
         mylib says: Hello World!
     """).split('\n')
     parser = ConsoleLogParser(stream=iter(log), harness_config=harness_config)
-    list(parser.parse())
+    parser.parse()
     assert parser.state == parser.STATE.PASSED
     assert parser.matched_lines == ['Hello World!']
 
@@ -36,7 +36,7 @@ def test_if_console_log_parser_fails_for_one_line_type():
         Explicit is better than implicit.
     """).split('\n')
     parser = ConsoleLogParser(stream=iter(log), harness_config=harness_config)
-    list(parser.parse())
+    parser.parse()
     assert parser.state == parser.STATE.FAILED
 
 
@@ -54,7 +54,7 @@ def test_if_console_log_parser_passes_for_not_ordered_multi_line(resources: Path
     }
     with open(log_file, encoding='UTF-8') as file:
         parser = ConsoleLogParser(stream=iter(file), harness_config=harness_config)
-        list(parser.parse())
+        parser.parse()
         assert parser.state == parser.STATE.PASSED
         assert parser.matched_lines == [
             'Philosopher 4 [C:-1]        STARVING\n',
@@ -78,7 +78,7 @@ def test_if_console_log_parser_fails_for_not_ordered_multi_line(resources: Path)
     }
     with open(log_file, encoding='UTF-8') as file:
         parser = ConsoleLogParser(stream=iter(file), harness_config=harness_config)
-        list(parser.parse())
+        parser.parse()
         assert parser.state == parser.STATE.FAILED
 
 
@@ -96,7 +96,7 @@ def test_if_console_log_parser_passes_for_ordered_multi_line(resources: Path):
     }
     with open(log_file, encoding='UTF-8') as file:
         parser = ConsoleLogParser(stream=iter(file), harness_config=harness_config)
-        list(parser.parse())
+        parser.parse()
         assert parser.state == parser.STATE.PASSED
 
 
@@ -120,5 +120,5 @@ def test_if_console_log_parser_fails_for_ordered_multi_line():
         ]
     }
     parser = ConsoleLogParser(stream=iter(log), harness_config=harness_config)
-    list(parser.parse())
+    parser.parse()
     assert parser.state == parser.STATE.FAILED


### PR DESCRIPTION
Changes was made to make it possible to use "parse" method in more intuitive way in pure pytest tests - without calling list to iterate through generator.

Logic connected with Subtest plugin was moved to ztest_log_parser.py file.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>