### PR TITLE
Fix URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pytest tests --collect-only
 
 Run tests only for specific platforms:
 ```
-pytest tests --platform=qemu_x86 --platform=nrf51dk_nrf51422
+pytest tests --platform=native_posix --platform=nrf52840dk_nrf52840
 ```
 
 Provide directory to search for board configuration files:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Twister v2
 
-[![Run tests](https://github.com/PerMac/TwisterV2/actions/workflows/main.yaml/badge.svg?branch=poc)](https://github.com/PerMac/TwisterV2/actions/workflows/main.yaml)
+[![Run tests](https://github.com/zephyrproject-rtos/twister/actions/workflows/main.yaml/badge.svg?branch=main)](https://github.com/zephyrproject-rtos/twister/actions/workflows/main.yaml)
 [![codecov](https://codecov.io/gh/zephyrproject-rtos/twister/branch/main/graph/badge.svg?token=F8DSSX20B5)](https://codecov.io/gh/zephyrproject-rtos/twister)
 
 Pytest plugin to run Zephyr tests and collect results.


### PR DESCRIPTION
`Run tests` badge has old URL. This PR fixes it.