### PR TITLE
Improve logging for WestBuilder

### DIFF
--- a/src/twister2/builder/west_builder.py
+++ b/src/twister2/builder/west_builder.py
@@ -17,8 +17,7 @@ class WestBuilder(BuilderAbstract):
         """
         Build Zephyr application with `west`.
         """
-        west = shutil.which('west')
-        if west is None:
+        if (west := shutil.which('west')) is None:
             raise TwisterBuildException('west not found')
 
         command = [
@@ -41,19 +40,28 @@ class WestBuilder(BuilderAbstract):
             process = subprocess.run(
                 command,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             )
         except subprocess.CalledProcessError as e:
-            logger.error('Failed building %s for %s', build_config.source_dir, build_config.platform)
+            logger.exception(
+                'An exception has been raised for build subprocess: %s for %s',
+                build_config.source_dir, build_config.platform
+            )
             raise TwisterBuildException('Building error') from e
         else:
             if process.returncode == 0:
+                self._log_output(process.stdout, logging.DEBUG)
                 logger.info('Finished building %s for %s', build_config.source_dir, build_config.platform)
             else:
-                logger.error(process.stderr.decode())
-                raise TwisterBuildException(
-                    f'Failed building {build_config.source_dir} for platform: {build_config.platform}'
-                )
+                self._log_output(process.stdout, logging.INFO)
+                msg = f'Failed building {build_config.source_dir} for platform: {build_config.platform}'
+                logger.error(msg)
+                raise TwisterBuildException(msg)
+
+    @staticmethod
+    def _log_output(output: bytes, level: int) -> None:
+        for line in output.decode().split('\n'):
+            logger.log(level, line)
 
     @staticmethod
     def _prepare_cmake_args(cmake_args: list[str]) -> str:

--- a/tests/builder/west_builder_test.py
+++ b/tests/builder/west_builder_test.py
@@ -41,7 +41,7 @@ def test_if_west_builder_builds_code_from_source_without_errors(
     patched_run.assert_called_with(
         ['west', 'build', 'source', '--pristine', 'always', '--board', 'native_posix',
          '--test-item', 'bt', '--build-dir', 'build', '--', '-DCONFIG_NEWLIB_LIBC=y'],
-        stdout=-1, stderr=-1
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT
     )
 
 


### PR DESCRIPTION
Because all errors from `west` are redirected to `stdout` instead of `stderr` we have to log `stdout` in case of any error during building. 