### PR TITLE
Added regex to quarantine

### DIFF
--- a/tests/data/quarantine/regex_example.yml
+++ b/tests/data/quarantine/regex_example.yml
@@ -3,4 +3,3 @@
   platforms:
     - qemu_cortex_..
   comment: "regex example"
-  use_regex: true

--- a/tests/data/quarantine/regex_example.yml
+++ b/tests/data/quarantine/regex_example.yml
@@ -1,0 +1,6 @@
+- scenarios:
+    - .*\.common_\w+_(1|2)
+  platforms:
+    - qemu_cortex_..
+  comment: "regex example"
+  use_regex: true


### PR DESCRIPTION
Follow some changes proposed in TwisterV1:
1. Added simulation as a filter to quarantine
2. Added regex to filter scenarios (I added regex to be allowed also in other fields: platforms, architectures and simulations),
Example quarantine file:
```
- scenarios:
  - kernel.common.(misra|tls)
  comment: "link to issue"

# quarantine kernel.common scenario for all platforms with name started from nrf53
- scenarios:
  - kernel.common
  platforms:
  - nrf53.*

# quarantine all scenarios where simulation is qemu, without reason and no regex
- simulations:
  - qemu
```