### PR TITLE
plugin: fix bug in creating output directory

### DIFF
--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -187,7 +187,7 @@ def pytest_configure(config: pytest.Config):
 
     xdist_worker = hasattr(config, 'workerinput')  # xdist worker
 
-    if not config.option.collectonly or xdist_worker:
+    if not config.option.collectonly and not xdist_worker:
         choice = config.option.clear
         if config.option.build_only and choice == 'no':
             msg = 'To apply "--build-only" option, "--clear" option cannot be set as "no".'


### PR DESCRIPTION
Output directory should be cleaned or renamed only in main worker/ process - not for each xdist worker/subprocess.

Without this fix, when tests are run with command:
```
pytest -vv -s --log-level=INFO -o log_cli=true --clear=archive --platform=native_posix --results-json=twister-out/results.json samples/philosophers -n 4 
```
Then 4 output directories are created (for each xdist worker) what is wrong, because all artifacts, logs and reports should be placed into one output directory.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>