### PR TITLE
Check if test is runnable base on board and specification

### DIFF
--- a/src/twister2/device/hardware_adapter.py
+++ b/src/twister2/device/hardware_adapter.py
@@ -13,7 +13,7 @@ import serial
 
 from twister2.device.device_abstract import DeviceAbstract
 from twister2.device.hardware_map import HardwareMap
-from twister2.exceptions import TwisterException, TwisterFlashException
+from twister2.exceptions import TwisterFlashException
 from twister2.helper import log_command
 from twister2.twister_config import TwisterConfig
 
@@ -30,8 +30,6 @@ class HardwareAdapter(DeviceAbstract):
         :param twister_config: twister configuration
         :param hardware_map: device hardware map
         """
-        if not isinstance(hardware_map, HardwareMap):
-            raise TwisterException('hardware_map must be an instance of HardwareMap')
         super().__init__(twister_config, **kwargs)
         self.hardware_map = hardware_map
         self.connection: serial.Serial | None = None

--- a/src/twister2/device/hardware_map.py
+++ b/src/twister2/device/hardware_map.py
@@ -10,10 +10,10 @@ import yaml
 class HardwareMap:
     """Class keeps configuration for connected hardware."""
     id: str
-    product: str
-    platform: str
-    runner: str
-    connected: bool
+    product: str = ''
+    platform: str = ''
+    runner: str = ''
+    connected: bool = False
     available: bool = False
     notes: str = ''
     probe_id: str = ''

--- a/src/twister2/fixtures/common.py
+++ b/src/twister2/fixtures/common.py
@@ -1,0 +1,79 @@
+"""
+Module contains common code for all fixtures.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import pytest
+
+from twister2.exceptions import TwisterConfigurationException
+from twister2.platform_specification import PlatformSpecification
+from twister2.twister_config import TwisterConfig
+from twister2.yaml_test_specification import YamlTestSpecification
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class State:
+    should_run: bool
+    message: str = ''  # message for logging
+    reason: str = ''  # skip reason
+
+    def __bool__(self) -> bool:
+        return self.should_run
+
+
+class TestSetupManager:
+    """Helper class to handle all setup required for test execution."""
+
+    def __init__(self, request: pytest.FixtureRequest) -> None:
+        self.request = request
+        self.twister_config: TwisterConfig = request.config.twister_config  # type: ignore
+        self.nodeid: str = request.node.nodeid
+        self.specification: YamlTestSpecification = request.session.specifications.get(self.nodeid)  # type: ignore
+        if not self.specification:
+            msg = f'Could not find test specification for test {request.node.nodeid}'
+            logger.error(msg)
+            raise TwisterConfigurationException(msg)
+        self.platform: PlatformSpecification = self.twister_config.get_platform(self.specification.platform)
+        self.build_only: bool = self.twister_config.build_only or self.specification.build_only
+        self.device_testing: bool = self.twister_config.device_testing
+        self.runnable: bool = self.specification.runnable
+        self.is_executable: State = self.should_be_executed(
+            self.build_only, self.device_testing, self.runnable, self.platform.type
+        )
+
+    @staticmethod
+    def should_be_executed(build_only: bool, device_testing: bool, runnable: bool, platform_type: str) -> State:
+        """Verify if test should be executed based on provided factors"""
+        if build_only:
+            return State(
+                False,
+                'Skipping test after building due to build-only being selected',
+                'Built but not executed due to build-only being selected'
+            )
+        if platform_type == 'mcu' and device_testing is False:
+            return State(
+                False,
+                'Skipping test after building because platform type is "mcu", '
+                'but device-testing was selected',
+                'Built but not executed because device-testing was not selected for platform type mcu'
+            )
+        if runnable is False:
+            return State(
+                False,
+                'Skipping test after building because it is not runnable',
+                'Built but not executed bcause the test is not runnable'
+            )
+        return State(True)
+
+    def get_device_type(self) -> str:
+        if self.platform.type == 'mcu':
+            return 'hardware'
+        elif self.platform.type == 'native':
+            return 'native'
+        else:
+            return ''

--- a/src/twister2/fixtures/fixtures.py
+++ b/src/twister2/fixtures/fixtures.py
@@ -1,0 +1,9 @@
+from twister2.fixtures.common import TestSetupManager
+
+import pytest
+
+
+@pytest.fixture(name='setup_manager', scope='function')
+def fixture_setup_manager(request: pytest.FixtureRequest) -> TestSetupManager:
+    """Test setup manager"""
+    return TestSetupManager(request)

--- a/src/twister2/fixtures/log_parser.py
+++ b/src/twister2/fixtures/log_parser.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Generator
 
 import pytest
 from pytest_subtests import SubTests
 
 from twister2.device.device_abstract import DeviceAbstract
-from twister2.exceptions import TwisterConfigurationException
+from twister2.fixtures.common import TestSetupManager
 from twister2.log_parser.factory import LogParserFactory
 from twister2.log_parser.log_parser_abstract import LogParserAbstract
 
@@ -16,21 +15,21 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope='function')
 def log_parser(
-        request: pytest.FixtureRequest, dut: DeviceAbstract, subtests: SubTests
-) -> Generator[LogParserAbstract, None, None]:
+        dut: DeviceAbstract, subtests: SubTests, setup_manager: TestSetupManager
+) -> LogParserAbstract | None:
     """Return log parser."""
-    spec = request.session.specifications.get(request.node.nodeid)  # type: ignore
-    if not spec:
-        msg = f'Could not find test specification for test {request.node.nodeid}'
-        logger.error(msg)
-        raise TwisterConfigurationException(msg)
+    spec = setup_manager.specification
 
     parser_name = spec.harness or 'ztest'  # make ztest default parser
     harness_config = spec.harness_config
     ignore_faults = spec.ignore_faults
 
-    parser_class = LogParserFactory.get_parser(parser_name)
-    yield parser_class(stream=dut.iter_stdout,
-                       harness_config=harness_config,
-                       ignore_faults=ignore_faults,
-                       subtests_fixture=subtests)
+    # check if test should be executed, if not than do not create log parser as it won't be used
+    if setup_manager.is_executable:
+        parser_class = LogParserFactory.get_parser(parser_name)
+        return parser_class(stream=dut.iter_stdout,
+                            harness_config=harness_config,
+                            ignore_faults=ignore_faults,
+                            subtests_fixture=subtests)
+    else:
+        return None

--- a/src/twister2/report/helper.py
+++ b/src/twister2/report/helper.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 
 import pytest
 
-from twister2.yaml_test_function import YamlFunction
-
 
 def get_suite_name(item: pytest.Item) -> str:
     """Return suite name."""
@@ -51,9 +49,18 @@ def get_item_platform(item: pytest.Item) -> str:
 
 def get_item_platform_allow(item: pytest.Item) -> str:
     """Return allowed platforms."""
-    if isinstance(item, YamlFunction):
-        return ' '.join(item.function.spec.platform_allow)
+    if hasattr(item.session, 'specification'):
+        if spec := item.session.specification.get(item.nodeid):
+            return ' '.join(spec.platform_allow)
     return ''
+
+
+def get_item_runnable_status(item: pytest.Item) -> bool:
+    """Return runnable status."""
+    if hasattr(item.session, 'specification'):
+        if spec := item.session.specification.get(item.nodeid):
+            return spec.runnable
+    return True
 
 
 def get_item_tags(item: pytest.Item) -> str:
@@ -63,3 +70,10 @@ def get_item_tags(item: pytest.Item) -> str:
     else:
         tags = []
     return ' '.join(tags)
+
+
+def get_item_build_only_status(item: pytest.Item) -> bool:
+    """Return True if test is build_only"""
+    if item.get_closest_marker('build_only'):
+        return True
+    return False

--- a/src/twister2/report/test_plan_plugin.py
+++ b/src/twister2/report/test_plan_plugin.py
@@ -11,9 +11,11 @@ from _pytest.terminal import TerminalReporter
 
 from twister2.report.base_report_writer import BaseReportWriter
 from twister2.report.helper import (
+    get_item_build_only_status,
     get_item_platform,
     get_item_platform_allow,
     get_item_quarantine,
+    get_item_runnable_status,
     get_item_tags,
     get_item_type,
     get_suite_name,
@@ -50,6 +52,8 @@ class TestPlanPlugin:
             platform=get_item_platform(item),
             tags=get_item_tags(item),
             type=get_item_type(item),
+            build_only=get_item_build_only_status(item),
+            runnable=get_item_runnable_status(item),
             platform_allow=get_item_platform_allow(item),
             quarantine=get_item_quarantine(item),
         )

--- a/src/twister2/twister_config.py
+++ b/src/twister2/twister_config.py
@@ -24,23 +24,25 @@ class TwisterConfig:
     platforms: list[PlatformSpecification] = field(default_factory=list, repr=False)
     hardware_map_list: list[HardwareMap] = field(default_factory=list, repr=False)
     device_testing: bool = False
+    fixtures: list[str] = field(default_factory=list, repr=False)
     extra_args_cli: list = field(default_factory=list)
 
     @classmethod
     def create(cls, config: pytest.Config) -> TwisterConfig:
         """Create new instance from pytest.Config."""
         zephyr_base: str = (
-            config.getoption('zephyr_base')
+            config.option.zephyr_base
             or config.getini('zephyr_base')
             or os.environ.get('ZEPHYR_BASE', '')
         )
-        build_only: bool = config.getoption('--build-only')
-        default_platforms: list[str] = config.getoption('--platform')
-        board_root: list[str] = config.getoption('--board-root')
+        build_only: bool = config.option.build_only
+        default_platforms: list[str] = config.option.platform
+        board_root: list[str] = config.option.board_root or config.getini('board_root')
         platforms: list[PlatformSpecification] = config._platforms  # type: ignore
-        output_dir: str = config.getoption('--outdir')
-        hardware_map_file: str = config.getoption('--hardware-map')
-        device_testing: bool = config.getoption('--device-testing')
+        output_dir: str = config.option.output_dir
+        hardware_map_file: str = config.option.hardware_map
+        device_testing: bool = config.option.device_testing
+        fixtures: list[str] = config.option.fixtures
         extra_args_cli: list[str] = config.getoption('--extra-args')
 
         hardware_map_list: list[HardwareMap] = []
@@ -64,6 +66,7 @@ class TwisterConfig:
             output_dir=output_dir,
             hardware_map_list=hardware_map_list,
             device_testing=device_testing,
+            fixtures=fixtures,
             extra_args_cli=extra_args_cli,
         )
         return cls(**data)

--- a/src/twister2/yaml_file.py
+++ b/src/twister2/yaml_file.py
@@ -43,7 +43,7 @@ def read_test_specifications_from_yaml(
     :param twister_config: twister configuration
     :return: generator of yaml test specifications
     """
-    processor = YamlSpecificationProcessor(filepath, twister_config.zephyr_base)
+    processor = YamlSpecificationProcessor(twister_config, filepath)
 
     platforms = (
         platform for platform in twister_config.platforms

--- a/tests/fixtures/common_test.py
+++ b/tests/fixtures/common_test.py
@@ -1,0 +1,18 @@
+import pytest
+
+from twister2.fixtures.common import TestSetupManager
+
+
+@pytest.mark.parametrize(
+    'build_only, device_testing, runnable, platform_type, expected',
+    [
+        (True, False, False, 'any', False),
+        (False, True, False, 'any', False),
+        (False, True, False, 'mcu', False),
+        (False, False, True, 'mcu', False),
+        (False, False, True, 'any', True),
+    ]
+)
+def test_if_test_should_be_skipped(build_only, device_testing, runnable, platform_type, expected):
+    result = TestSetupManager.should_be_executed(build_only, device_testing, runnable, platform_type)
+    assert result.should_run == expected

--- a/tests/report/report_plugin_test.py
+++ b/tests/report/report_plugin_test.py
@@ -95,10 +95,13 @@ def test_if_pytest_generates_json_results_with_expected_data(pytester, extra_arg
         'platform',
         'tags',
         'type',
+        'build_only',
+        'runnable',
         'platform_allow',
         'status',
         'quarantine',
         'duration',
+        'execution_time',
         'message',
         'subtests',
     }


### PR DESCRIPTION
We need to consider separately twiser's tests and regular python tests. 
For twister's tests it is easy to run building setup and omit test body using simply `if` statement yaml test implementation.  For regular tests it is much more complicated (we don't want to force users to add additional lines to each test like:
```python
def test_foo(...):
    if specification.runnably is False:
        return
    ...
```
So the simples way to omit test execution is to mark test as skip (just after test has been built). 

Example pytest terminal report for test which are not `runnable` or `build-only` can look like that:

```
samples/hello_world/sample.yaml::sample.basic.helloworld[native_posix] <- ../twister2/src/twister2/yaml_test_function.py PASSED
tests/hello_world/hello_world_test.py::test_hello_world[native_posix:scenario1] PASSED 
tests/hello_world/hello_world_test.py::test_hello_world[native_posix:scenario2] PASSED 
tests/hello_world/hello_world_test.py::test_hello_world[native_posix:scenario3] SKIPPED (Built but not executed due to test is not runnable)
tests/hello_world/hello_world_test.py::test_hello_world_2[native_posix:scenario1] PASSED 
tests/hello_world/hello_world_test.py::test_hello_world_2[native_posix:scenario2] PASSED                                                                                                                                                  
```

If we run pytest with param ``--build-only`` all regular tests will be marked as `SKIPPED `(if building passed or as `ERROR` if failed) and twister's tests as `PASSED` (or another pytest status): 
```
samples/hello_world/sample.yaml::sample.basic.helloworld[native_posix] <- ../twister2/src/twister2/yaml_test_function.py PASSED
tests/hello_world/hello_world_test.py::test_hello_world[native_posix:scenario1] SKIPPED (Built but not executed due to build-only is selected) 
tests/hello_world/hello_world_test.py::test_hello_world[native_posix:scenario2] SKIPPED (Built but not executed due to build-only is selected)
tests/hello_world/hello_world_test.py::test_hello_world[native_posix:scenario3] SKIPPED (Built but not executed due to build-only is selected)
tests/hello_world/hello_world_test.py::test_hello_world_2[native_posix:scenario1] SKIPPED (Built but not executed due to build-only is selected)
tests/hello_world/hello_world_test.py::test_hello_world_2[native_posix:scenario2] SKIPPED (Built but not executed due to build-only is selected)
```

This inconvenient we can try to solve by generating custom report (eg. JUnit xml report) with proper status. For example all tests which are marked as `SKIPPED (Built but not executed due to build-only is selected)` we can set status `PASSED`. 
This custom report can be use in CI (e.g. by Jenkins) to report all tests with proper status.

Signed-off-by: Fundakowski, Lukasz <lukasz.fundakowski@nordicsemi.no>