### PR TITLE
Improve generating build variants (scenarios) for regular tests

### DIFF
--- a/src/twister2/generate_tests_plugin.py
+++ b/src/twister2/generate_tests_plugin.py
@@ -37,13 +37,7 @@ class Variant:
 def get_scenarios_from_fixture(metafunc: pytest.Metafunc) -> list[str]:
     """Return scenarios selected by fixture `build_specification`."""
     if mark := metafunc.definition.get_closest_marker('build_specification'):
-        scenarios = list(mark.args)
-        if not scenarios:
-            logger.warning(
-                'At least one `scenario` should be added to `build_specification` decorator in test: %s',
-                metafunc.definition.nodeid
-            )
-        return scenarios
+        return list(mark.args)
     return []
 
 
@@ -58,9 +52,12 @@ def get_scenarios_from_yaml(spec_file: Path) -> list[str]:
 
 def pytest_generate_tests(metafunc: pytest.Metafunc):
     # generate parametrized tests for each selected platform for ordinary pytest tests
-    # if `specification` fixture is used
-    if 'specification' not in metafunc.fixturenames:
+    # if `build_specification` marker is used
+    if not metafunc.definition.get_closest_marker('build_specification'):
         return
+
+    # incject fixture for parametrized tests
+    metafunc.definition.fixturenames.append('specification')
 
     twister_config = metafunc.config.twister_config  # type: ignore[attr-defined]
 

--- a/tests/twister2_plugin_test.py
+++ b/tests/twister2_plugin_test.py
@@ -72,11 +72,12 @@ def test_if_regular_tests_work_with_specification_file(pytester, resources):
     test_file_content = textwrap.dedent("""
         import pytest
 
-        def test_foo(specification, builder):
+        @pytest.mark.build_specification
+        def test_foo(builder):
             pass
 
         @pytest.mark.build_specification('scenario1', 'scenario2')
-        def test_bar(specification, builder):
+        def test_bar(builder):
             pass
     """)
     test_file = pytester.path / 'tests' / 'foobar_test.py'


### PR DESCRIPTION
This change allows to use regular tests without providing additional fixture `specification`. 
Test can be written simpler:
```python
@pytest.mark.build_specification('scenario1', 'scenario2')
def test_hello_world(log_parser):
    log_parser.parse(timeout=5)
    assert log_parser.state == 'PASSED'
```

Signed-off-by: Fundakowski, Lukasz <lukasz.fundakowski@nordicsemi.no>