### PR TITLE
Fix passing CMake extra arguments

### DIFF
--- a/src/twister2/builder/builder_abstract.py
+++ b/src/twister2/builder/builder_abstract.py
@@ -15,7 +15,9 @@ class BuildConfig:
     build_dir: str | Path
     platform: str
     scenario: str
-    extra_args: list[str] = field(default_factory=list)
+    extra_configs: list[str] = field(default_factory=list)
+    extra_args_spec: list[str] = field(default_factory=list)
+    extra_args_cli: list[str] = field(default_factory=list)
 
 
 class BuilderAbstract(abc.ABC):

--- a/src/twister2/fixtures/builder.py
+++ b/src/twister2/fixtures/builder.py
@@ -12,6 +12,7 @@ from twister2.builder.builder_abstract import BuildConfig, BuilderAbstract
 from twister2.builder.factory import BuilderFactory
 from twister2.exceptions import TwisterConfigurationException
 from twister2.twister_config import TwisterConfig
+from twister2.yaml_test_specification import YamlTestSpecification
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
 def builder(request: pytest.FixtureRequest) -> Generator[BuilderAbstract, None, None]:
     """Build hex files for test suite."""
     twister_config: TwisterConfig = request.config.twister_config  # type: ignore
-    spec = request.session.specifications.get(request.node.nodeid)  # type: ignore
+    spec: YamlTestSpecification = request.session.specifications.get(request.node.nodeid)  # type: ignore
     if not spec:
         msg = f'Could not find test specification for test {request.node.nodeid}'
         logger.error(msg)
@@ -36,7 +37,9 @@ def builder(request: pytest.FixtureRequest) -> Generator[BuilderAbstract, None, 
         platform=spec.platform,
         build_dir=spec.build_dir,
         scenario=spec.scenario,
-        extra_args=spec.extra_args
+        extra_configs=spec.extra_configs,
+        extra_args_spec=spec.extra_args,
+        extra_args_cli=twister_config.extra_args_cli
     )
     build_manager = BuildManager(request.config.option.output_dir)
     build_manager.build(builder, build_config)

--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -135,6 +135,18 @@ def pytest_addoption(parser: pytest.Parser):
         choices=('west',),
         help='Select builder type (default=%(default)s)'
     )
+    twister_group.addoption(
+        '--extra-args',
+        default=[],
+        action='append',
+        help='Extra CMake arguments which will be passed to CMake during '
+             'building. May be called multiple times. The key-value entries '
+             'will be prefixed with -D before being passed to CMake. '
+             'For example: '
+             'pytest --extra-args=USE_CCACHE=0 '
+             'will be translated to '
+             'cmake -DUSE_CCACHE=0'
+    )
 
 
 def pytest_configure(config: pytest.Config):

--- a/src/twister2/twister_config.py
+++ b/src/twister2/twister_config.py
@@ -24,6 +24,7 @@ class TwisterConfig:
     platforms: list[PlatformSpecification] = field(default_factory=list, repr=False)
     hardware_map_list: list[HardwareMap] = field(default_factory=list, repr=False)
     device_testing: bool = False
+    extra_args_cli: list = field(default_factory=list)
 
     @classmethod
     def create(cls, config: pytest.Config) -> TwisterConfig:
@@ -40,6 +41,7 @@ class TwisterConfig:
         output_dir: str = config.getoption('--outdir')
         hardware_map_file: str = config.getoption('--hardware-map')
         device_testing: bool = config.getoption('--device-testing')
+        extra_args_cli: list[str] = config.getoption('--extra-args')
 
         hardware_map_list: list[HardwareMap] = []
         if hardware_map_file:
@@ -62,6 +64,7 @@ class TwisterConfig:
             output_dir=output_dir,
             hardware_map_list=hardware_map_list,
             device_testing=device_testing,
+            extra_args_cli=extra_args_cli,
         )
         return cls(**data)
 

--- a/src/twister2/yaml_test_specification.py
+++ b/src/twister2/yaml_test_specification.py
@@ -65,7 +65,6 @@ class YamlTestSpecification:
         self.arch_exclude = string_to_set(self.arch_exclude)
         self.depends_on = string_to_set(self.depends_on)
         self.extra_sections = string_to_list(self.extra_sections)
-        self.extra_configs = string_to_list(self.extra_configs)
         self.extra_args = string_to_list(self.extra_args)
         self.integration_platforms = string_to_list(self.integration_platforms)
 

--- a/tests/builder/conftest.py
+++ b/tests/builder/conftest.py
@@ -11,5 +11,5 @@ def fixture_build_config() -> BuildConfig:
         build_dir='build',
         platform='native_posix',
         scenario='bt',
-        extra_args=['CONFIG_NEWLIB_LIBC=y']
+        extra_args_spec=['CONF_FILE=prj_single.conf']
     )

--- a/tests/twister2_plugin_test.py
+++ b/tests/twister2_plugin_test.py
@@ -13,10 +13,12 @@ def test_twister_help(pytester):
         '*--build-only*build only*',
         '*--platform=PLATFORM*build tests for specific platforms*',
         '*--board-root=PATH*directory to search for board configuration files*',
-        '*--zephyr-base=PAT*base directory for Zephyr*',
+        '*--zephyr-base=PATH*base directory for Zephyr*',
         '*--quarantine-list=*',
         '*--clear={no,delete,archive}*',
         '*Clear twister artifacts*',
+        '*--extra-args=EXTRA_ARGS*',
+        '*Extra CMake arguments*',
     ])
 
 


### PR DESCRIPTION
`--test-item` option in `west` do not allows to parse properly `extra_configs` and `extra_args` from `.yaml` files with name different than `testcase.yaml` and `sample.yaml`. So, changes in this PR cause, that `CMake` arguments will be passed to `west` directly as additional arguments after `--` option. This will allow to handle properly `extra_configs` and `extra_args` form other `.yaml` files like `testspec.yaml`. Moreover, new argument with passing `--extra-args` from CLI was added.