### PR TITLE
Rename yaml module and function classes

### DIFF
--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -14,7 +14,7 @@ from twister2.log import configure_logging
 from twister2.platform_specification import search_platforms
 from twister2.quarantine_plugin import QuarantinePlugin
 from twister2.twister_config import TwisterConfig
-from twister2.yaml_file import YamlFile
+from twister2.yaml_file import YamlModule
 
 SAMPLE_FILENAME: str = 'sample.yaml'
 TESTCASE_FILENAME: str = 'testcase.yaml'
@@ -34,7 +34,7 @@ pytest_plugins = (
 def pytest_collect_file(parent, path):
     # discovers all yaml tests in test directory
     if path.basename in (SAMPLE_FILENAME, TESTCASE_FILENAME):
-        return YamlFile.from_parent(parent, path=Path(path))
+        return YamlModule.from_parent(parent, path=Path(path))
 
 
 def pytest_addoption(parser: pytest.Parser):

--- a/src/twister2/report/helper.py
+++ b/src/twister2/report/helper.py
@@ -3,7 +3,7 @@ Module contains helper function used in report package.
 """
 import pytest
 
-from twister2.yaml_test_function import YamlTestFunction
+from twister2.yaml_test_function import YamlFunction
 
 
 def get_suite_name(item: pytest.Item) -> str:
@@ -49,7 +49,7 @@ def get_item_platform(item: pytest.Item) -> str:
 
 def get_item_platform_allow(item: pytest.Item) -> str:
     """Return allowed platforms."""
-    if isinstance(item, YamlTestFunction):
+    if isinstance(item, YamlFunction):
         return ' '.join(item.function.spec.platform_allow)
     return ''
 

--- a/src/twister2/yaml_file.py
+++ b/src/twister2/yaml_file.py
@@ -15,13 +15,13 @@ import pytest
 
 from twister2.specification_processor import YamlSpecificationProcessor
 from twister2.twister_config import TwisterConfig
-from twister2.yaml_test_function import YamlTestFunction, yaml_test_function_factory
+from twister2.yaml_test_function import YamlFunction, yaml_test_function_factory
 from twister2.yaml_test_specification import YamlTestSpecification
 
 logger = logging.getLogger(__name__)
 
 
-class YamlFile(pytest.File):
+class YamlModule(pytest.File):
     """Class for collecting tests from a yaml file."""
 
     def collect(self):
@@ -29,7 +29,7 @@ class YamlFile(pytest.File):
         twister_config = self.config.twister_config
         # read all tests from yaml file and generate pytest test functions
         for spec in read_test_specifications_from_yaml(self.path, twister_config):
-            test_function: YamlTestFunction = yaml_test_function_factory(spec=spec, parent=self)
+            test_function: YamlFunction = yaml_test_function_factory(spec=spec, parent=self)
             yield test_function
 
 

--- a/src/twister2/yaml_test_function.py
+++ b/src/twister2/yaml_test_function.py
@@ -20,9 +20,9 @@ from twister2.yaml_test_specification import YamlTestSpecification
 logger = logging.getLogger(__name__)
 
 
-def yaml_test_function_factory(spec: YamlTestSpecification, parent: Any) -> YamlTestFunction:
+def yaml_test_function_factory(spec: YamlTestSpecification, parent: Any) -> YamlFunction:
     """Generate test function."""
-    function = YamlTestFunction.from_parent(
+    function = YamlFunction.from_parent(
         name=spec.name,
         originalname=spec.original_name,
         parent=parent,
@@ -52,7 +52,7 @@ def add_markers_from_specification(obj: pytest.Item | pytest.Function, spec: Yam
         obj.add_marker(pytest.mark.skip('Skipped in yaml specification'))
 
 
-class YamlTestFunction(pytest.Function):
+class YamlFunction(pytest.Function):
     """Wrapper for pytest.Function to extend functionality."""
 
 


### PR DESCRIPTION
To keep similar names for yaml tests with regular pytest tests changing name of `YamlFile` class to `YamlModule` and `YamlTestFunction` to `YamlFunction`. After that we will have `Module` for pytest tests and `YamlModule` for twister tests, and similar for `Function` and `YamlFunction`.

Example results of running `pytest --collect-only` command:
```
<YamlModule tests/common/testcase.yaml>
  <YamlFunction kernel.common[native_posix]>
  <YamlFunction kernel.common.tls[native_posix]>
  <YamlFunction kernel.common.misra[native_posix]>
  <YamlFunction kernel.common.nano32[native_posix]>
  <YamlFunction kernel.common.nano64[native_posix]>
  <YamlFunction kernel.common.picolibc[native_posix]>
<Module tests/hello_world/hello_world_test.py>
  <Function test_hello_world[native_posix:scenario1]>
  <Function test_hello_world[native_posix:scenario2]>
  <Function test_hello_world[native_posix:scenario3]>
  <Function test_hello_world_2[native_posix:scenario1]>
  <Function test_hello_world_2[native_posix:scenario2]>
<Module tests/registration/test_registration.py>
  <Function test_LightweightM2M_1_1_int_101>
    LightweightM2M-1.1-int-101
  <Function test_LightweightM2M_1_1_int_102>
    LightweightM2M-1.1-int-102
        
<Module tests/shell_module_pytest/shell_test.py>
  <Function test_shell>
```

Signed-off-by: Fundakowski, Lukasz <lukasz.fundakowski@nordicsemi.no>