### PR TITLE
device: add generate_command to abstract class

### DIFF
--- a/src/twister2/device/device_abstract.py
+++ b/src/twister2/device/device_abstract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import logging
 import os
+from pathlib import Path
 from typing import Generator
 
 from twister2.twister_config import TwisterConfig
@@ -34,6 +35,14 @@ class DeviceAbstract(abc.ABC):
 
     @abc.abstractmethod
     def disconnect(self) -> None:
+        pass
+
+    def generate_command(self, build_dir: Path | str) -> None:
+        """
+        Generate command which will be used during flashing or running device.
+
+        :param build_dir: path to directory with built application
+        """
         pass
 
     def flash_and_run(self, timeout: float = 60.0) -> None:

--- a/src/twister2/device/hardware_adapter.py
+++ b/src/twister2/device/hardware_adapter.py
@@ -76,7 +76,7 @@ class HardwareAdapter(DeviceAbstract):
             self.connection = None
             logger.info('Closed serial connection for %s', self.hardware_map.serial)
 
-    def generate_command(self, build_dir: Path | str) -> list[str]:
+    def generate_command(self, build_dir: Path | str) -> None:
         """
         Return command to flash.
 

--- a/src/twister2/device/native_simulator_adapter.py
+++ b/src/twister2/device/native_simulator_adapter.py
@@ -46,7 +46,7 @@ class NativeSimulatorAdapter(DeviceAbstract):
             'env': self.env,
         }
 
-    def generate_command(self, build_dir: Path | str) -> list[str]:
+    def generate_command(self, build_dir: Path | str) -> None:
         """
         Return command to run.
 


### PR DESCRIPTION
After creating separate and public method for generating flashing or running command it is necessary to add this method to abstract class.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>