### PR TITLE
Add build_config and builder to BuildManager

### DIFF
--- a/src/twister2/builder/west_builder.py
+++ b/src/twister2/builder/west_builder.py
@@ -66,7 +66,7 @@ class WestBuilder(BuilderAbstract):
         """
         cmake_args = []
 
-        cmake_args += (self._prepare_args(build_config.extra_configs))
+        cmake_args += (self._prepare_extra_configs(build_config.extra_configs))
         cmake_args += (self._prepare_args(build_config.extra_args_spec))
         cmake_args += (self._prepare_args(build_config.extra_args_cli))
 
@@ -75,6 +75,10 @@ class WestBuilder(BuilderAbstract):
     @staticmethod
     def _prepare_args(args: list[str]) -> list[str]:
         return ['-D{}'.format(arg.replace('"', '')) for arg in args]
+
+    @staticmethod
+    def _prepare_extra_configs(args: list[str]) -> list[str]:
+        return ['-D{}'.format(arg) for arg in args]
 
     @staticmethod
     def _log_output(output: bytes, level: int) -> None:

--- a/src/twister2/fixtures/builder.py
+++ b/src/twister2/fixtures/builder.py
@@ -17,8 +17,8 @@ from twister2.yaml_test_specification import YamlTestSpecification
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope='function')
-def builder(request: pytest.FixtureRequest) -> Generator[BuilderAbstract, None, None]:
+@pytest.fixture(name='build_manager', scope='function')
+def fixture_build_manager(request: pytest.FixtureRequest) -> Generator[BuildManager, None, None]:
     """Build hex files for test suite."""
     twister_config: TwisterConfig = request.config.twister_config  # type: ignore
     spec: YamlTestSpecification = request.session.specifications.get(request.node.nodeid)  # type: ignore
@@ -41,6 +41,11 @@ def builder(request: pytest.FixtureRequest) -> Generator[BuilderAbstract, None, 
         extra_args_spec=spec.extra_args,
         extra_args_cli=twister_config.extra_args_cli
     )
-    build_manager = BuildManager(request.config.option.output_dir)
-    build_manager.build(builder, build_config)
-    yield builder
+    build_manager = BuildManager(request.config.option.output_dir, build_config, builder)
+    yield build_manager
+
+
+@pytest.fixture(scope='function')
+def builder(build_manager: BuildManager) -> Generator[BuilderAbstract, None, None]:
+    build_manager.build()
+    yield build_manager.builder

--- a/tests/builder/build_manager_test.py
+++ b/tests/builder/build_manager_test.py
@@ -1,15 +1,13 @@
+import copy
 import threading
 import time
 from contextlib import contextmanager
-from pathlib import Path
 from unittest import mock
 
 import pytest
 
 from twister2.builder.build_manager import BuildManager, BuildStatus
 from twister2.exceptions import TwisterBuildException
-
-BUILD_DIR = 'build'
 
 
 class MockBuilder(mock.Mock):
@@ -23,8 +21,8 @@ def mocked_builder():
 
 
 @pytest.fixture
-def build_manager(tmp_path) -> BuildManager:
-    build_manager = BuildManager(tmp_path, wait_build_timeout=2)
+def build_manager(tmp_path, build_config, mocked_builder) -> BuildManager:
+    build_manager = BuildManager(tmp_path, build_config, mocked_builder, wait_build_timeout=2)
     return build_manager
 
 
@@ -38,60 +36,59 @@ def run_job_in_thread(job):
 
 
 def test_if_status_can_be_updated(build_manager):
-    build_manager.update_status('build_dir_1', BuildStatus.DONE)
-    assert build_manager.get_status('build_dir_1') == BuildStatus.DONE
+    build_manager.update_status(BuildStatus.DONE)
+    assert build_manager.get_status() == BuildStatus.DONE
 
 
-def test_if_status_was_updated_after_build(build_manager, mocked_builder, build_config):
-    build_manager.update_status(BUILD_DIR, BuildStatus.NOT_DONE)
+def test_if_status_was_updated_after_build(build_manager):
+    build_manager.update_status(BuildStatus.NOT_DONE)
 
-    build_manager.build(builder=mocked_builder, build_config=build_config)
-    assert build_manager.get_status(BUILD_DIR) == BuildStatus.DONE
+    build_manager.build()
+    assert build_manager.get_status() == BuildStatus.DONE
 
 
-def test_if_build_manager_is_waiting_for_finish_another_build(build_manager, mocked_builder, build_config, monkeypatch):
+def test_if_build_manager_is_waiting_for_finish_another_build(build_manager, monkeypatch):
+    build_manager_2 = copy.deepcopy(build_manager)
     _wait_for_build_to_finish = mock.MagicMock()
     monkeypatch.setattr(build_manager, '_wait_for_build_to_finish', _wait_for_build_to_finish)
-    build_manager.update_status(BUILD_DIR, BuildStatus.IN_PROGRESS)
+    build_manager_2.update_status(BuildStatus.IN_PROGRESS)
 
-    build_manager.build(builder=mocked_builder, build_config=build_config)
-    assert build_manager.get_status(BUILD_DIR) == BuildStatus.IN_PROGRESS
+    build_manager.build()
+    assert build_manager.get_status() == BuildStatus.IN_PROGRESS
     _wait_for_build_to_finish.assert_called_once()
 
 
-def test_if_test_is_failed_when_build_status_was_failed(build_manager, mocked_builder, build_config):
-    build_manager.update_status(BUILD_DIR, BuildStatus.FAILED)
+def test_if_test_is_failed_when_build_status_was_failed(build_manager):
+    build_manager.update_status(BuildStatus.FAILED)
 
-    expected_msg = f'Found in .*twister_builder.json the build status is set as {BuildStatus.FAILED} for: {BUILD_DIR}'
+    expected_msg = f'Found in .*twister_builder.json the build status is set as {BuildStatus.FAILED} ' \
+                   f'for: {build_manager.build_config.build_dir}'
     with pytest.raises(TwisterBuildException, match=expected_msg):
-        build_manager.build(builder=mocked_builder, build_config=build_config)
+        build_manager.build()
 
 
-def test_if_update_status_detect_properly_that_status_was_already_set(tmp_path):
-    build_manager_1 = BuildManager(tmp_path)
-    build_manager_2 = BuildManager(tmp_path)
-    build_dir = Path('samples/hello_world')
-
-    status = build_manager_1.get_status(build_dir)
+def test_if_update_status_detect_properly_that_status_was_already_set(build_manager):
+    build_manager_2 = copy.deepcopy(build_manager)
+    status = build_manager.get_status()
     assert status == BuildStatus.NOT_DONE
-    status = build_manager_2.get_status(build_dir)
+    status = build_manager_2.get_status()
     assert status == BuildStatus.NOT_DONE
 
-    assert build_manager_1.update_status(build_dir, BuildStatus.IN_PROGRESS)
-    assert not build_manager_2.update_status(build_dir, BuildStatus.IN_PROGRESS)
+    assert build_manager.update_status(BuildStatus.IN_PROGRESS)
+    assert not build_manager_2.update_status(BuildStatus.IN_PROGRESS)
 
 
 def test_if_build_manager_does_not_build_when_source_is_already_built(
-        build_manager, mocked_builder, build_config, monkeypatch
+        build_manager, monkeypatch
 ):
     _wait_for_build_to_finish = mock.MagicMock()
     _build = mock.MagicMock()
     monkeypatch.setattr(build_manager, '_wait_for_build_to_finish', _wait_for_build_to_finish)
     monkeypatch.setattr(build_manager, '_build', _build)
-    build_manager.update_status(BUILD_DIR, BuildStatus.DONE)
+    build_manager.update_status(BuildStatus.DONE)
 
-    build_manager.build(builder=mocked_builder, build_config=build_config)
-    assert build_manager.get_status(BUILD_DIR) == BuildStatus.DONE
+    build_manager.build()
+    assert build_manager.get_status() == BuildStatus.DONE
     _wait_for_build_to_finish.assert_not_called()
     _build.assert_not_called()
 
@@ -106,40 +103,39 @@ def test_if_build_manager_waits_until_status_is_changed_to_done(
     While first process finished building second process should leave waiting loop.
     The build status should be updated by build manager to `DONE`.
     """
-    build_manager.update_status(BUILD_DIR, BuildStatus.IN_PROGRESS)
+    build_manager.update_status(BuildStatus.IN_PROGRESS)
 
     def update_status():
         time.sleep(0.1)
-        build_manager.update_status(BUILD_DIR, BuildStatus.DONE)
+        build_manager.update_status(BuildStatus.DONE)
 
     with run_job_in_thread(update_status):
         start_time = time.time()
-        build_manager.build(builder=mocked_builder, build_config=build_config)
+        build_manager.build()
         finish_time = time.time()
-    assert build_manager.get_status(BUILD_DIR) == BuildStatus.DONE
+    assert build_manager.get_status() == BuildStatus.DONE
     assert finish_time - start_time < 2  # Should not wait longer than 1 second
 
 
-def test_if_build_manager_waits_until_status_is_changed_to_failed(
-        build_manager, mocked_builder, build_config
-):
-    build_manager.update_status(BUILD_DIR, BuildStatus.IN_PROGRESS)
+def test_if_build_manager_waits_until_status_is_changed_to_failed(build_manager):
+    build_manager.update_status(BuildStatus.IN_PROGRESS)
 
     def update_status():
         time.sleep(0.1)
-        build_manager.update_status(BUILD_DIR, BuildStatus.FAILED)
+        build_manager.update_status(BuildStatus.FAILED)
 
     expected_msg = f'Found in .*twister_builder.json the build status is set as ' \
-                   f'{BuildStatus.FAILED} for: {BUILD_DIR}'
+                   f'{BuildStatus.FAILED} for: {build_manager.build_config.build_dir}'
     with run_job_in_thread(update_status):
         with pytest.raises(TwisterBuildException, match=expected_msg):
-            build_manager.build(builder=mocked_builder, build_config=build_config)
-    assert build_manager.get_status(BUILD_DIR) == BuildStatus.FAILED
+            build_manager.build()
+    assert build_manager.get_status() == BuildStatus.FAILED
 
 
-def test_if_build_manager_waits_until_timed_out(build_manager, mocked_builder, build_config):
-    build_manager.update_status(BUILD_DIR, BuildStatus.IN_PROGRESS)
+def test_if_build_manager_waits_until_timed_out(build_manager):
+    build_manager.update_status(BuildStatus.IN_PROGRESS)
     build_manager.wait_build_timeout = 1
-    expected_msg = f'Timed out waiting for another thread to finish building: {BUILD_DIR}'
+    expected_msg = f'Timed out waiting for another thread to finish building: ' \
+                   f'{build_manager.build_config.build_dir}'
     with pytest.raises(TwisterBuildException, match=expected_msg):
-        build_manager.build(builder=mocked_builder, build_config=build_config)
+        build_manager.build()


### PR DESCRIPTION
This changes allow to create test scenario like:
```
@pytest.mark.build_specification
def test_upgrade(dut: DeviceAbstract, build_manager: BuildManager):
    # assert wait_for_message(dut.iter_stdout, "0.0.0")
    new_build_dir = str(build_manager.build_config.build_dir) + '_second_image'
    build_manager.build_config.build_dir = new_build_dir
    build_manager.build_config.extra_configs.append('CONFIG_MCUBOOT_IMAGE_VERSION="1.1.1+1"')
    build_manager.build()
    dut.generate_command(new_build_dir)
    dut.flash_and_run()
    # assert wait_for_message(dut.iter_stdout, "1.1.1")
```