### PR TITLE
specification_processor: add depends_on filtration

### DIFF
--- a/src/twister2/specification_processor.py
+++ b/src/twister2/specification_processor.py
@@ -170,6 +170,7 @@ def should_be_skip(test_spec: YamlTestSpecification, platform: PlatformSpecifica
     # TODO: Implement #1 #13
     if any([
         should_skip_for_arch(test_spec, platform),
+        should_skip_for_depends_on(test_spec, platform),
         should_skip_for_min_flash(test_spec, platform),
         should_skip_for_min_ram(test_spec, platform),
         should_skip_for_platform(test_spec, platform),
@@ -248,6 +249,19 @@ def should_skip_for_min_flash(test_spec: YamlTestSpecification, platform: Platfo
 def should_skip_for_pytest_harness(test_spec: YamlTestSpecification, platform: PlatformSpecification) -> bool:
     if test_spec.harness == 'pytest':
         _log_test_skip(test_spec, platform, 'test harness "pytest" is natively supported by pytest')
+        return True
+    return False
+
+
+def should_skip_for_depends_on(test_spec: YamlTestSpecification, platform: PlatformSpecification) -> bool:
+    not_supported_dependencies = []
+    for dependency in test_spec.depends_on:
+        if dependency not in platform.supported:
+            not_supported_dependencies.append(dependency)
+    if not_supported_dependencies:
+        reason = f'"{_join_strings(not_supported_dependencies)}" not occur in the "supported" section in the ' \
+                 'platform definition yaml'
+        _log_test_skip(test_spec, platform, reason)
         return True
     return False
 

--- a/tests/specification_processor_test.py
+++ b/tests/specification_processor_test.py
@@ -11,6 +11,7 @@ from twister2.specification_processor import (
     _join_strings,
     is_runnable,
     should_skip_for_arch,
+    should_skip_for_depends_on,
     should_skip_for_min_flash,
     should_skip_for_min_ram,
     should_skip_for_platform,
@@ -173,6 +174,18 @@ def test_should_skip_for_min_flash_positive(testcase, platform):
     testcase.min_flash = 200
     platform.flash = 300
     assert should_skip_for_min_flash(testcase, platform) is False
+
+
+def test_should_skip_for_depends_on_negative(testcase, platform):
+    testcase.depends_on = {'spi'}
+    platform.supported = {'gpio'}
+    assert should_skip_for_depends_on(testcase, platform)
+
+
+def test_should_skip_for_depends_on_positive(testcase, platform):
+    testcase.depends_on = {'spi'}
+    platform.supported = {'gpio', 'spi'}
+    assert should_skip_for_depends_on(testcase, platform) is False
 
 
 @pytest.mark.parametrize('in_put,out_put', [


### PR DESCRIPTION
Tests which depends on specific hardware elements listed in platform yaml file definition should be skipped.

Can be tested by following commands:
1. Twister v1
```
./scripts/twister -vv --inline-logs -T tests/drivers/spi/dt_spec --platform=qemu_cortex_m3 --platform=nrf52840dk_nrf52840
```
2. Twister v2
```
pytest -vv -s -o log_cli=true --clear=archive --log-level=INFO --results-json=twister-out/results.json tests/drivers/spi/dt_spec --platform=qemu_cortex_m3 --platform=nrf52840dk_nrf52840
```

In both cases only one test should be executed (built) (for `nrf52840dk_nrf52840`).


Fixes: #13

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>