### PR TITLE
Use source_dir in testspec.yml

### DIFF
--- a/src/twister2/yaml_test_specification.py
+++ b/src/twister2/yaml_test_specification.py
@@ -131,6 +131,7 @@ class TestSchema(Schema):
     skip = fields.Bool()
     slow = fields.Bool()
     sysbuild = fields.Bool()
+    source_dir = fields.Str()
 
 
 class CommonSchema(TestSchema):


### PR DESCRIPTION
POC:
added `source_dir` to testspec.yml.
When creating new test with twisterV2, do not need to create `src` dir with sources. Only `testspec.yml` (and pytest scenarios) is required, but you must point to existing test / sample.
Example of testspec.yml:
```
common:
    tags: introduction
    source_dir: samples/hello_world
    integration_platforms:
      - native_posix
tests:
  sample.basic.helloworld2:
    harness: console
    harness_config:
      type: one_line
      regex:
        - "Hello World! (.*)"
  kernel.fifo:
    tags: kernel
    source_dir: tests/kernel/fifo/fifo_api
```
Test `sample.basic.helloworld2` will use image build from `<ZEPHYR_BASE>/samples/hello_world`,
test `kernel.fifo` will use image build from `<ZEPHYR_BASE>tests/kernel/fifo/fifo_api`

`source_dir` is relative to ZEPHYR_BASE,
if ZEPHYR_BASE is /home/grch/zephyrproject/zephyr, then:
source_dir: samples/hello_world => /home/grch/zephyrproject/zephyr/samples/hello_world
source_dir: ../../ncs/nrf/samples/tfm/tfm_hello_world => /home/grch/ncs/nrf/samples/tfm/tfm_hello_world

or one can use an absolute path:
source_dir: /home/grch/tmp/hello_world

