### PR TITLE
Pr/add kconfig dts filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ dmypy.json
 
 # test outputs
 twister-out*
+
+# KConfig DTS filtration
+*parsetab.py

--- a/src/twister2/builder/build_manager.py
+++ b/src/twister2/builder/build_manager.py
@@ -118,7 +118,7 @@ class BuildManager:
 
     def _build(self, builder: BuilderAbstract) -> None:
         try:
-            builder.build(self.build_config)
+            builder.run_cmake_and_build(self.build_config)
         except Exception:
             self.update_status(BuildStatus.FAILED)
             raise

--- a/src/twister2/builder/build_manager.py
+++ b/src/twister2/builder/build_manager.py
@@ -118,7 +118,7 @@ class BuildManager:
 
     def _build(self, builder: BuilderAbstract) -> None:
         try:
-            builder.run_cmake_and_build(self.build_config)
+            builder.build(self.build_config)
         except Exception:
             self.update_status(BuildStatus.FAILED)
             raise

--- a/src/twister2/builder/builder_abstract.py
+++ b/src/twister2/builder/builder_abstract.py
@@ -13,7 +13,8 @@ class BuildConfig:
     zephyr_base: str | Path
     source_dir: str | Path
     build_dir: str | Path
-    platform: str
+    platform_arch: str
+    platform_name: str
     scenario: str
     kconfig_dts_filter: str
     extra_configs: list[str] = field(default_factory=list)
@@ -28,9 +29,9 @@ class BuilderAbstract(abc.ABC):
         return f'{self.__class__.__name__}()'
 
     @abc.abstractmethod
-    def run_cmake_and_build(self, build_config: BuildConfig) -> None:
+    def build(self, build_config: BuildConfig) -> None:
         """
-        Run CMake and build Zephyr application.
+        Build Zephyr application.
 
         :param build_config: build configuration
         """

--- a/src/twister2/builder/builder_abstract.py
+++ b/src/twister2/builder/builder_abstract.py
@@ -15,6 +15,7 @@ class BuildConfig:
     build_dir: str | Path
     platform: str
     scenario: str
+    kconfig_dts_filter: str
     extra_configs: list[str] = field(default_factory=list)
     extra_args_spec: list[str] = field(default_factory=list)
     extra_args_cli: list[str] = field(default_factory=list)
@@ -27,9 +28,9 @@ class BuilderAbstract(abc.ABC):
         return f'{self.__class__.__name__}()'
 
     @abc.abstractmethod
-    def build(self, build_config: BuildConfig) -> None:
+    def run_cmake_and_build(self, build_config: BuildConfig) -> None:
         """
-        Build Zephyr application.
+        Run CMake and build Zephyr application.
 
         :param build_config: build configuration
         """

--- a/src/twister2/builder/cmakecache.py
+++ b/src/twister2/builder/cmakecache.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# vim: set syntax=python ts=4 :
+#
+# Copyright (c) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+from collections import OrderedDict
+
+class CMakeCacheEntry:
+    '''Represents a CMake cache entry.
+
+    This class understands the type system in a CMakeCache.txt, and
+    converts the following cache types to Python types:
+
+    Cache Type    Python type
+    ----------    -------------------------------------------
+    FILEPATH      str
+    PATH          str
+    STRING        str OR list of str (if ';' is in the value)
+    BOOL          bool
+    INTERNAL      str OR list of str (if ';' is in the value)
+    ----------    -------------------------------------------
+    '''
+
+    # Regular expression for a cache entry.
+    #
+    # CMake variable names can include escape characters, allowing a
+    # wider set of names than is easy to match with a regular
+    # expression. To be permissive here, use a non-greedy match up to
+    # the first colon (':'). This breaks if the variable name has a
+    # colon inside, but it's good enough.
+    CACHE_ENTRY = re.compile(
+        r'''(?P<name>.*?)                               # name
+         :(?P<type>FILEPATH|PATH|STRING|BOOL|INTERNAL)  # type
+         =(?P<value>.*)                                 # value
+        ''', re.X)
+
+    @classmethod
+    def _to_bool(cls, val):
+        # Convert a CMake BOOL string into a Python bool.
+        #
+        #   "True if the constant is 1, ON, YES, TRUE, Y, or a
+        #   non-zero number. False if the constant is 0, OFF, NO,
+        #   FALSE, N, IGNORE, NOTFOUND, the empty string, or ends in
+        #   the suffix -NOTFOUND. Named boolean constants are
+        #   case-insensitive. If the argument is not one of these
+        #   constants, it is treated as a variable."
+        #
+        # https://cmake.org/cmake/help/v3.0/command/if.html
+        val = val.upper()
+        if val in ('ON', 'YES', 'TRUE', 'Y'):
+            return 1
+        elif val in ('OFF', 'NO', 'FALSE', 'N', 'IGNORE', 'NOTFOUND', ''):
+            return 0
+        elif val.endswith('-NOTFOUND'):
+            return 0
+        else:
+            try:
+                v = int(val)
+                return v != 0
+            except ValueError as exc:
+                raise ValueError('invalid bool {}'.format(val)) from exc
+
+    @classmethod
+    def from_line(cls, line, line_no):
+        # Comments can only occur at the beginning of a line.
+        # (The value of an entry could contain a comment character).
+        if line.startswith('//') or line.startswith('#'):
+            return None
+
+        # Whitespace-only lines do not contain cache entries.
+        if not line.strip():
+            return None
+
+        m = cls.CACHE_ENTRY.match(line)
+        if not m:
+            return None
+
+        name, type_, value = (m.group(g) for g in ('name', 'type', 'value'))
+        if type_ == 'BOOL':
+            try:
+                value = cls._to_bool(value)
+            except ValueError as exc:
+                args = exc.args + ('on line {}: {}'.format(line_no, line),)
+                raise ValueError(args) from exc
+        elif type_ in ['STRING', 'INTERNAL']:
+            # If the value is a CMake list (i.e. is a string which
+            # contains a ';'), convert to a Python list.
+            if ';' in value:
+                value = value.split(';')
+
+        return CMakeCacheEntry(name, value)
+
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+    def __str__(self):
+        fmt = 'CMakeCacheEntry(name={}, value={})'
+        return fmt.format(self.name, self.value)
+
+
+class CMakeCache:
+    '''Parses and represents a CMake cache file.'''
+
+    @staticmethod
+    def from_file(cache_file):
+        return CMakeCache(cache_file)
+
+    def __init__(self, cache_file):
+        self.cache_file = cache_file
+        self.load(cache_file)
+
+    def load(self, cache_file):
+        entries = []
+        with open(cache_file, 'r') as cache:
+            for line_no, line in enumerate(cache):
+                entry = CMakeCacheEntry.from_line(line, line_no)
+                if entry:
+                    entries.append(entry)
+        self._entries = OrderedDict((e.name, e) for e in entries)
+
+    def get(self, name, default=None):
+        entry = self._entries.get(name)
+        if entry is not None:
+            return entry.value
+        else:
+            return default
+
+    def get_list(self, name, default=None):
+        if default is None:
+            default = []
+        entry = self._entries.get(name)
+        if entry is not None:
+            value = entry.value
+            if isinstance(value, list):
+                return value
+            elif isinstance(value, str):
+                return [value] if value else []
+            else:
+                msg = 'invalid value {} type {}'
+                raise RuntimeError(msg.format(value, type(value)))
+        else:
+            return default
+
+    def __contains__(self, name):
+        return name in self._entries
+
+    def __getitem__(self, name):
+        return self._entries[name].value
+
+    def __setitem__(self, name, entry):
+        if not isinstance(entry, CMakeCacheEntry):
+            msg = 'improper type {} for value {}, expecting CMakeCacheEntry'
+            raise TypeError(msg.format(type(entry), entry))
+        self._entries[name] = entry
+
+    def __delitem__(self, name):
+        del self._entries[name]
+
+    def __iter__(self):
+        return iter(self._entries.values())

--- a/src/twister2/builder/expr_parser.py
+++ b/src/twister2/builder/expr_parser.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2016 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import logging
+import os
+import re
+import sys
+import threading
+
+try:
+    import ply.lex as lex
+    import ply.yacc as yacc
+except ImportError:
+    sys.exit("PLY library for Python 3 not installed.\n"
+             "Please install the ply package using your workstation's\n"
+             "package manager or the 'pip' tool.")
+
+_logger = logging.getLogger('twister')
+
+reserved = {
+    'and' : 'AND',
+    'or' : 'OR',
+    'not' : 'NOT',
+    'in' : 'IN',
+}
+
+tokens = [
+    "HEX",
+    "STR",
+    "INTEGER",
+    "EQUALS",
+    "NOTEQUALS",
+    "LT",
+    "GT",
+    "LTEQ",
+    "GTEQ",
+    "OPAREN",
+    "CPAREN",
+    "OBRACKET",
+    "CBRACKET",
+    "COMMA",
+    "SYMBOL",
+    "COLON",
+] + list(reserved.values())
+
+def t_HEX(t):
+    r"0x[0-9a-fA-F]+"
+    t.value = str(int(t.value, 16))
+    return t
+
+def t_INTEGER(t):
+    r"\d+"
+    t.value = str(int(t.value))
+    return t
+
+def t_STR(t):
+    r'\"([^\\\n]|(\\.))*?\"|\'([^\\\n]|(\\.))*?\''
+    # nip off the quotation marks
+    t.value = t.value[1:-1]
+    return t
+
+t_EQUALS = r"=="
+
+t_NOTEQUALS = r"!="
+
+t_LT = r"<"
+
+t_GT = r">"
+
+t_LTEQ = r"<="
+
+t_GTEQ = r">="
+
+t_OPAREN = r"[(]"
+
+t_CPAREN = r"[)]"
+
+t_OBRACKET = r"\["
+
+t_CBRACKET = r"\]"
+
+t_COMMA = r","
+
+t_COLON = ":"
+
+def t_SYMBOL(t):
+    r"[A-Za-z_][0-9A-Za-z_]*"
+    t.type = reserved.get(t.value, "SYMBOL")
+    return t
+
+t_ignore = " \t\n"
+
+def t_error(t):
+    raise SyntaxError("Unexpected token '%s'" % t.value)
+
+lex.lex()
+
+precedence = (
+    ('left', 'OR'),
+    ('left', 'AND'),
+    ('right', 'NOT'),
+    ('nonassoc', 'EQUALS', 'NOTEQUALS', 'GT', 'LT', 'GTEQ', 'LTEQ', 'IN'),
+)
+
+def p_expr_or(p):
+    'expr : expr OR expr'
+    p[0] = ("or", p[1], p[3])
+
+def p_expr_and(p):
+    'expr : expr AND expr'
+    p[0] = ("and", p[1], p[3])
+
+def p_expr_not(p):
+    'expr : NOT expr'
+    p[0] = ("not", p[2])
+
+def p_expr_parens(p):
+    'expr : OPAREN expr CPAREN'
+    p[0] = p[2]
+
+def p_expr_eval(p):
+    """expr : SYMBOL EQUALS const
+            | SYMBOL NOTEQUALS const
+            | SYMBOL GT number
+            | SYMBOL LT number
+            | SYMBOL GTEQ number
+            | SYMBOL LTEQ number
+            | SYMBOL IN list
+            | SYMBOL COLON STR"""
+    p[0] = (p[2], p[1], p[3])
+
+def p_expr_single(p):
+    """expr : SYMBOL"""
+    p[0] = ("exists", p[1])
+
+def p_func(p):
+    """expr : SYMBOL OPAREN arg_intr CPAREN"""
+    p[0] = [p[1]]
+    p[0].append(p[3])
+
+def p_arg_intr_single(p):
+    """arg_intr : const"""
+    p[0] = [p[1]]
+
+def p_arg_intr_mult(p):
+    """arg_intr : arg_intr COMMA const"""
+    p[0] = copy.copy(p[1])
+    p[0].append(p[3])
+
+def p_list(p):
+    """list : OBRACKET list_intr CBRACKET"""
+    p[0] = p[2]
+
+def p_list_intr_single(p):
+    """list_intr : const"""
+    p[0] = [p[1]]
+
+def p_list_intr_mult(p):
+    """list_intr : list_intr COMMA const"""
+    p[0] = copy.copy(p[1])
+    p[0].append(p[3])
+
+def p_const(p):
+    """const : STR
+             | number"""
+    p[0] = p[1]
+
+def p_number(p):
+    """number : INTEGER
+              | HEX"""
+    p[0] = p[1]
+
+def p_error(p):
+    if p:
+        raise SyntaxError("Unexpected token '%s'" % p.value)
+    else:
+        raise SyntaxError("Unexpected end of expression")
+
+if "PARSETAB_DIR" not in os.environ:
+    parser = yacc.yacc(debug=0)
+else:
+    parser = yacc.yacc(debug=0, outputdir=os.environ["PARSETAB_DIR"])
+
+def ast_sym(ast, env):
+    if ast in env:
+        return str(env[ast])
+    return ""
+
+def ast_sym_int(ast, env):
+    if ast in env:
+        v = env[ast]
+        if v.startswith("0x") or v.startswith("0X"):
+            return int(v, 16)
+        else:
+            return int(v, 10)
+    return 0
+
+def ast_expr(ast, env, edt):
+    if ast[0] == "not":
+        return not ast_expr(ast[1], env, edt)
+    elif ast[0] == "or":
+        return ast_expr(ast[1], env, edt) or ast_expr(ast[2], env, edt)
+    elif ast[0] == "and":
+        return ast_expr(ast[1], env, edt) and ast_expr(ast[2], env, edt)
+    elif ast[0] == "==":
+        return ast_sym(ast[1], env) == ast[2]
+    elif ast[0] == "!=":
+        return ast_sym(ast[1], env) != ast[2]
+    elif ast[0] == ">":
+        return ast_sym_int(ast[1], env) > int(ast[2])
+    elif ast[0] == "<":
+        return ast_sym_int(ast[1], env) < int(ast[2])
+    elif ast[0] == ">=":
+        return ast_sym_int(ast[1], env) >= int(ast[2])
+    elif ast[0] == "<=":
+        return ast_sym_int(ast[1], env) <= int(ast[2])
+    elif ast[0] == "in":
+        return ast_sym(ast[1], env) in ast[2]
+    elif ast[0] == "exists":
+        return bool(ast_sym(ast[1], env))
+    elif ast[0] == ":":
+        return bool(re.match(ast[2], ast_sym(ast[1], env)))
+    elif ast[0] == "dt_compat_enabled":
+        compat = ast[1][0]
+        for node in edt.nodes:
+            if compat in node.compats and node.status == "okay":
+                return True
+        return False
+    elif ast[0] == "dt_alias_exists":
+        alias = ast[1][0]
+        for node in edt.nodes:
+            if alias in node.aliases and node.status == "okay":
+                return True
+        return False
+    elif ast[0] == "dt_enabled_alias_with_parent_compat":
+        # Checks if the DT has an enabled alias node whose parent has
+        # a given compatible. For matching things like gpio-leds child
+        # nodes, which do not have compatibles themselves.
+        #
+        # The legacy "dt_compat_enabled_with_alias" form is still
+        # accepted but is now deprecated and causes a warning. This is
+        # meant to give downstream users some time to notice and
+        # adjust. Its argument order only made sense under the (bad)
+        # assumption that the gpio-leds child node has the same compatible
+
+        alias = ast[1][0]
+        compat = ast[1][1]
+
+        return ast_handle_dt_enabled_alias_with_parent_compat(edt, alias,
+                                                              compat)
+    elif ast[0] == "dt_compat_enabled_with_alias":
+        compat = ast[1][0]
+        alias = ast[1][1]
+
+        _logger.warning('dt_compat_enabled_with_alias("%s", "%s"): '
+                        'this is deprecated, use '
+                        'dt_enabled_alias_with_parent_compat("%s", "%s") '
+                        'instead',
+                        compat, alias, alias, compat)
+
+        return ast_handle_dt_enabled_alias_with_parent_compat(edt, alias,
+                                                              compat)
+    elif ast[0] == "dt_label_with_parent_compat_enabled":
+        compat = ast[1][1]
+        label = ast[1][0]
+        node = edt.label2node.get(label)
+        if node is not None:
+            parent = node.parent
+        else:
+            return False
+        return parent is not None and parent.status == 'okay' and parent.matching_compat == compat
+    elif ast[0] == "dt_chosen_enabled":
+        chosen = ast[1][0]
+        node = edt.chosen_node(chosen)
+        if node and node.status == "okay":
+            return True
+        return False
+    elif ast[0] == "dt_nodelabel_enabled":
+        label = ast[1][0]
+        node = edt.label2node.get(label)
+        if node and node.status == "okay":
+            return True
+        return False
+
+def ast_handle_dt_enabled_alias_with_parent_compat(edt, alias, compat):
+    # Helper shared with the now deprecated
+    # dt_compat_enabled_with_alias version.
+
+    for node in edt.nodes:
+        parent = node.parent
+        if parent is None:
+            continue
+        if (node.status == "okay" and alias in node.aliases and
+                    parent.matching_compat == compat):
+            return True
+
+    return False
+
+mutex = threading.Lock()
+
+def parse(expr_text, env, edt):
+    """Given a text representation of an expression in our language,
+    use the provided environment to determine whether the expression
+    is true or false"""
+
+    # Like it's C counterpart, state machine is not thread-safe
+    mutex.acquire()
+    try:
+        ast = parser.parse(expr_text)
+    finally:
+        mutex.release()
+
+    return ast_expr(ast, env, edt)
+
+# Just some test code
+if __name__ == "__main__":
+
+    local_env = {
+        "A" : "1",
+        "C" : "foo",
+        "D" : "20",
+        "E" : 0x100,
+        "F" : "baz"
+    }
+
+
+    for line in open(sys.argv[1]).readlines():
+        lex.input(line)
+        for tok in iter(lex.token, None):
+            print(tok.type, tok.value)
+
+        parser = yacc.yacc()
+        print(parser.parse(line))
+
+        print(parse(line, local_env, None))

--- a/src/twister2/builder/kconfig_dts_filter.py
+++ b/src/twister2/builder/kconfig_dts_filter.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+import os
+import pickle
+import re
+import sys
+
+from pathlib import Path
+from twister2.builder import expr_parser
+from twister2.builder.cmakecache import CMakeCache
+
+logger = logging.getLogger(__name__)
+
+
+class KconfigDtsFilter:
+    config_re = re.compile('(CONFIG_[A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
+    dt_re = re.compile('([A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
+
+    def __init__(self, zephyr_base: str, build_dir: str | Path, platform_arch: str, platform_name: str,
+                 filter_exp: str) -> None:
+        self.build_dir: str = str(build_dir)
+        self.platform_arch: str = platform_arch
+        self.platform_name: str = platform_name
+        self.filter_exp: str = filter_exp
+
+        self.sysbuild: bool = False
+
+        # This is needed to load edt.pickle files by pickle.load().
+        sys.path.insert(0, os.path.join(zephyr_base, "scripts", "dts",
+                                        "python-devicetree", "src"))
+        from devicetree import edtlib
+
+    def filter(self) -> bool:
+
+        # # TODO: add handling for unit_testing
+        # if self.platform.name == "unit_testing":
+        #     return {}
+
+        # # TODO: add handling for sysbuild
+        # if self.testsuite.sysbuild:
+        #     # Load domain yaml to get default domain build directory
+        #     domain_path = os.path.join(self.build_dir, "domains.yaml")
+        #     domains = Domains.from_file(domain_path)
+        #     logger.debug("Loaded sysbuild domain data from %s" % (domain_path))
+        #     domain_build = domains.get_default_domain().build_dir
+        #     cmake_cache_path = os.path.join(domain_build, "CMakeCache.txt")
+        #     defconfig_path = os.path.join(domain_build, "zephyr", ".config")
+        #     edt_pickle = os.path.join(domain_build, "zephyr", "edt.pickle")
+        # else:
+        cmake_cache_path = os.path.join(self.build_dir, "CMakeCache.txt")
+        defconfig_path = os.path.join(self.build_dir, "zephyr", ".config")
+        edt_pickle = os.path.join(self.build_dir, "zephyr", "edt.pickle")
+
+        defconfig = {}
+        with open(defconfig_path, "r") as fp:
+            for line in fp.readlines():
+                m = self.config_re.match(line)
+                if not m:
+                    if line.strip() and not line.startswith("#"):
+                        sys.stderr.write("Unrecognized line %s\n" % line)
+                    continue
+                defconfig[m.group(1)] = m.group(2).strip()
+
+        cmake_conf = {}
+        try:
+            cache = CMakeCache.from_file(cmake_cache_path)
+        except FileNotFoundError:
+            cache = {}
+
+        for k in iter(cache):
+            cmake_conf[k.name] = k.value
+
+        filter_data = {
+            "ARCH": self.platform_arch,
+            "PLATFORM": self.platform_name
+        }
+        filter_data.update(os.environ)
+        filter_data.update(defconfig)
+        filter_data.update(cmake_conf)
+
+        # # TODO: add handling for sysbuild
+        # if self.testsuite.sysbuild and self.env.options.device_testing:
+        #     # Verify that twister's arguments support sysbuild.
+        #     # Twister sysbuild flashing currently only works with west, so
+        #     # --west-flash must be passed. Additionally, erasing the DUT
+        #     # before each test with --west-flash=--erase will inherently not
+        #     # work with sysbuild.
+        #     if self.env.options.west_flash is None:
+        #         logger.warning("Sysbuild test will be skipped. " +
+        #             "West must be used for flashing.")
+        #         return {os.path.join(self.platform.name, self.testsuite.name): True}
+        #     elif "--erase" in self.env.options.west_flash:
+        #         logger.warning("Sysbuild test will be skipped, " +
+        #             "--erase is not supported with --west-flash")
+        #         return {os.path.join(self.platform.name, self.testsuite.name): True}
+
+        try:
+            if os.path.exists(edt_pickle):
+                with open(edt_pickle, 'rb') as f:
+                    edt = pickle.load(f)
+            else:
+                edt = None
+            result = expr_parser.parse(self.filter_exp, filter_data, edt)
+
+        except (ValueError, SyntaxError) as se:
+            sys.stderr.write(
+                f"Failed processing kconfig and dts for {self.build_dir}\n")
+            raise se
+
+        return result

--- a/src/twister2/fixtures/builder.py
+++ b/src/twister2/fixtures/builder.py
@@ -36,7 +36,8 @@ def fixture_build_manager(
         scenario=spec.scenario,
         extra_configs=spec.extra_configs,
         extra_args_spec=spec.extra_args,
-        extra_args_cli=twister_config.extra_args_cli
+        extra_args_cli=twister_config.extra_args_cli,
+        kconfig_dts_filter=spec.filter
     )
     build_manager = BuildManager(request.config.option.output_dir, build_config, builder)
     yield build_manager

--- a/src/twister2/fixtures/builder.py
+++ b/src/twister2/fixtures/builder.py
@@ -21,6 +21,7 @@ def fixture_build_manager(
         request: pytest.FixtureRequest, setup_manager: TestSetupManager
 ) -> Generator[BuildManager, None, None]:
     """Build manager"""
+    platform = setup_manager.platform
     spec = setup_manager.specification
     twister_config = setup_manager.twister_config
 
@@ -31,7 +32,8 @@ def fixture_build_manager(
     build_config = BuildConfig(
         zephyr_base=setup_manager.twister_config.zephyr_base,
         source_dir=spec.source_dir,
-        platform=spec.platform,
+        platform_arch=platform.arch,
+        platform_name=platform.identifier,
         build_dir=spec.build_dir,
         scenario=spec.scenario,
         extra_configs=spec.extra_configs,


### PR DESCRIPTION
Initial draft of idea of applying KConfig and DTS filtration. I copied several files 1:1 from Twister v1. This draft is not ready for review.

Can be tested by:
```
pytest -vv -s --log-level=INFO -o log_cli=true --clear=archive --results-json=twister-out/results.json --platform=mps2_an385 samples/userspace/hello_world_user tests/drivers/sensor/sbs_gauge samples/arch/smp/pi 
```

Only one test should be passed:
`samples/userspace/hello_world_user/sample.yaml::sample.helloworld[mps2_an385]`
And two next should be skipped:
`tests/drivers/sensor/sbs_gauge/testcase.yaml::drivers.sbs_gauge[mps2_an385]`
`samples/arch/smp/pi/sample.yaml::sample.smp.pi[mps2_an385]`
