### PR TITLE
Add subparsers to twister-tools for the better separation commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,25 +163,26 @@ Scan connected devices and create hardware map:
 
 .. code-block:: sh
 
-  twister_tools --generate-hardware-map hardware_map.yaml
+  twister2 hardware-map --generate hardware_map.yaml
 
 
 Scan connected devices and list hardware map:
 
 .. code-block:: sh
 
-  twister_tools --list-hardware-map
+  twister2 hardware-map --list
 
 
 List all platforms:
 
 .. code-block:: sh
 
-  twister_tools --list-platforms
+  twister2 platforms --list
 
 
 List default platforms only:
 
 .. code-block:: sh
 
-  twister_tools --list-platforms --default-only
+  twister2 platforms --list --default-only
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ where = src
 pytest11 =
     twister = twister2.plugin
 console_scripts =
-    twister_tools = twister2.scripts.__main__:main
+    twister2 = twister2.scripts.__main__:main
 
 [flake8]
 max-line-length = 120

--- a/src/twister2/scripts/__main__.py
+++ b/src/twister2/scripts/__main__.py
@@ -7,54 +7,69 @@ from twister2.scripts.hardware_map import print_hardware_map, scan, write_to_fil
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--generate-hardware-map',
+    subparsers = parser.add_subparsers(dest='command')
+
+    hardware_subparser = subparsers.add_parser('hardware-map', help='hardware map')
+    meg = hardware_subparser.add_mutually_exclusive_group()
+    meg.add_argument(
+        '-g', '--generate',
         dest='hardware_map_path',
-        metavar='path',
+        metavar='PATH',
         help='generate hardware map',
     )
-    parser.add_argument(
-        '--list-hardware-map',
+    meg.add_argument(
+        '-l', '--list',
         dest='list_hardware_map',
         action='store_true',
         help='list hardware map',
     )
-    parser.add_argument(
+    hardware_subparser.add_argument(
         '--persistent',
         dest='persistent',
         action='store_true',
         help='Use persistent for searching hardware',
     )
-    parser.add_argument(
-        '--list-platforms',
+
+    platforms_subparser = subparsers.add_parser('platforms', help='platforms')
+    platforms_subparser.add_argument(
+        '-l', '--list',
         dest='list_platforms',
         action='store_true',
         help='list all available platforms',
     )
-    parser.add_argument(
+    platforms_subparser.add_argument(
         '--default-only',
         dest='default_only',
         action='store_true',
-        help='list only default platforms',
+        help='only default platforms',
     )
+
     args = parser.parse_args()
 
-    if args.hardware_map_path:
-        hardware_map_list = scan(persistent=args.persistent)
-        write_to_file(hardware_map_list=hardware_map_list, filename=args.hardware_map_path)
-        print_hardware_map(hardware_map_list)
-        return 0
-    if args.list_hardware_map:
-        hardware_map_list = scan(persistent=args.persistent)
-        print_hardware_map(hardware_map_list)
-        return 0
-    if args.list_platforms:
-        zephyr_base = os.environ['ZEPHYR_BASE']
-        platforms = search_platforms(zephyr_base=zephyr_base, default_only=args.default_only)
-        for platform in platforms:
-            print(platform.identifier)
-        print(f'\nTotal: {len(platforms)}')
-        return 0
+    if args.command == 'hardware-map':
+        if args.hardware_map_path:
+            hardware_map_list = scan(persistent=args.persistent)
+            write_to_file(hardware_map_list=hardware_map_list, filename=args.hardware_map_path)
+            print_hardware_map(hardware_map_list)
+            return 0
+        elif args.list_hardware_map:
+            hardware_map_list = scan(persistent=args.persistent)
+            print_hardware_map(hardware_map_list)
+            return 0
+        else:
+            hardware_subparser.print_help()
+            return -1
+    elif args.command == 'platforms':
+        if args.list_platforms:
+            zephyr_base = os.environ['ZEPHYR_BASE']
+            platforms = search_platforms(zephyr_base=zephyr_base, default_only=args.default_only)
+            for platform in platforms:
+                print(platform.identifier)
+            print(f'\nTotal: {len(platforms)}')
+            return 0
+        else:
+            platforms_subparser.print_help()
+            return -1
 
     parser.print_help()
     return 0


### PR DESCRIPTION
I made small refactoring for `twister-tools`.  
First I changed the name of the script to be shorter. Now it is `twister2` instead of `twister-tools`.
Second I created `subparsers` for hardware map and platforms to separate arguments for those two commands. 
I believe the change is simplifying the usage. 

Print help: `twister2 -h`

Print help for hardware map: `twister2 hardware-map -h`

Print help for platforms: `twister2 platforms -h`

Signed-off-by: Fundakowski, Lukasz <lukasz.fundakowski@nordicsemi.no>