### PR TITLE
Implement custom simulator addapter

### DIFF
--- a/src/twister2/device/device_abstract.py
+++ b/src/twister2/device/device_abstract.py
@@ -31,19 +31,19 @@ class DeviceAbstract(abc.ABC):
 
     @abc.abstractmethod
     def connect(self, timeout: float = 1) -> None:
-        pass
+        """Connect with the device (e.g. via UART)"""
 
     @abc.abstractmethod
     def disconnect(self) -> None:
-        pass
+        """Close a connection with the device"""
 
+    @abc.abstractmethod
     def generate_command(self, build_dir: Path | str) -> None:
         """
         Generate command which will be used during flashing or running device.
 
         :param build_dir: path to directory with built application
         """
-        pass
 
     def flash_and_run(self, timeout: float = 60.0) -> None:
         """

--- a/src/twister2/device/factory.py
+++ b/src/twister2/device/factory.py
@@ -5,8 +5,11 @@ from typing import Type
 
 from twister2.device.device_abstract import DeviceAbstract
 from twister2.device.hardware_adapter import HardwareAdapter
-from twister2.device.native_simulator_adapter import NativeSimulatorAdapter
 from twister2.device.qemu_adapter import QemuAdapter
+from twister2.device.simulator_adapter import (
+    CustomSimulatorAdapter,
+    NativeSimulatorAdapter,
+)
 from twister2.exceptions import TwisterRunException
 
 logger = logging.getLogger(__name__)
@@ -34,6 +37,7 @@ class DeviceFactory:
             raise TwisterRunException(f'There is no device with name "{name}"') from e
 
 
+DeviceFactory.register_device_class('custom', CustomSimulatorAdapter)
 DeviceFactory.register_device_class('native', NativeSimulatorAdapter)
 DeviceFactory.register_device_class('hardware', HardwareAdapter)
 DeviceFactory.register_device_class('qemu', QemuAdapter)

--- a/src/twister2/device/hardware_adapter.py
+++ b/src/twister2/device/hardware_adapter.py
@@ -122,7 +122,7 @@ class HardwareAdapter(DeviceAbstract):
         self.command = command
 
     def flash_and_run(self, timeout: float = 60.0) -> None:
-        if self.command == []:
+        if not self.command:
             msg = 'Flash command is empty, please verify if it was generated properly.'
             logger.error(msg)
             raise TwisterFlashException(msg)

--- a/src/twister2/device/qemu_adapter.py
+++ b/src/twister2/device/qemu_adapter.py
@@ -117,7 +117,7 @@ class QemuAdapter(DeviceAbstract):
         self._stop_job = True
         time.sleep(0.1)  # give a time to end while loop in running simulation
         if self._process is not None and self._process.returncode is None:
-            logger.debug('Stopping all running processes')
+            logger.debug('Stopping all running processes for PID %s', self._process.pid)
             # kill all child subprocesses
             for child in psutil.Process(self._process.pid).children(recursive=True):
                 try:

--- a/src/twister2/device/simulator_adapter.py
+++ b/src/twister2/device/simulator_adapter.py
@@ -3,17 +3,23 @@ This module implements adapter class for a device simulator.
 """
 from __future__ import annotations
 
+import abc
 import asyncio
 import asyncio.subprocess
 import logging
 import os
+import shutil
 import signal
 import subprocess
 import threading
 import time
+from asyncio.base_subprocess import BaseSubprocessTransport
+from functools import wraps
 from pathlib import Path
 from queue import Queue
 from typing import Generator
+
+import psutil
 
 from twister2.device import END_OF_DATA
 from twister2.device.device_abstract import DeviceAbstract
@@ -21,11 +27,27 @@ from twister2.exceptions import TwisterRunException
 from twister2.helper import log_command
 from twister2.twister_config import TwisterConfig
 
+
+# Workaround for RuntimeError: Event loop is closed
+# https://pythonalgos.com/runtimeerror-event-loop-is-closed-asyncio-fix/
+def silence_event_loop_closed(func):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+        except RuntimeError as e:
+            if str(e) != 'Event loop is closed':
+                raise
+
+    return wrapper
+
+
+BaseSubprocessTransport.__del__ = silence_event_loop_closed(BaseSubprocessTransport.__del__)  # type: ignore
+
 logger = logging.getLogger(__name__)
 
 
-class NativeSimulatorAdapter(DeviceAbstract):
-    """Adapter class for a device simulator."""
+class SimulatorAdapterBase(DeviceAbstract, abc.ABC):
 
     def __init__(self, twister_config: TwisterConfig, **kwargs) -> None:
         """
@@ -45,17 +67,8 @@ class NativeSimulatorAdapter(DeviceAbstract):
             'env': self.env,
         }
 
-    def generate_command(self, build_dir: Path | str) -> None:
-        """
-        Return command to run.
-
-        :param build_dir: build directory
-        :return: command to run
-        """
-        self.command = [str((Path(build_dir) / 'zephyr' / 'zephyr.exe').resolve())]
-
     def connect(self, timeout: float = 1) -> None:
-        pass
+        pass  # pragma: no cover
 
     def flash_and_run(self, timeout: float = 60.0) -> None:
         if not self.command:
@@ -70,6 +83,29 @@ class NativeSimulatorAdapter(DeviceAbstract):
         if self._exc is not None:
             logger.error('Simulation failed due to an exception: %s', self._exc)
             raise self._exc
+
+    def _run_simulation(self, timeout: float) -> None:
+        log_command(logger, 'Running command', self.command, level=logging.INFO)
+        try:
+            return_code: int = asyncio.run(self._run_command(timeout=timeout))
+        except subprocess.SubprocessError as e:
+            logger.error('Running simulation failed due to subprocess error %s', e)
+            self._exc = TwisterRunException(e.args)
+        except FileNotFoundError as e:
+            logger.error(f'Running simulation failed due to file not found: {e.filename}')
+            self._exc = TwisterRunException(f'File not found: {e.filename}')
+        except Exception as e:
+            logger.error('Running simulation failed: %s', e)
+            self._exc = TwisterRunException(e.args)
+        else:
+            if return_code == 0:
+                logger.info('Running simulation finished with return code %s', return_code)
+            elif return_code == -15:
+                logger.info('Running simulation stopped interrupted by user')
+            else:
+                logger.warning('Running simulation finished with return code %s', return_code)
+        finally:
+            self.queue.put(END_OF_DATA)  # indicate to the other threads that there will be no more data in queue
 
     async def _run_command(self, timeout: float = 60.):
         assert isinstance(self.command, (list, tuple, set))  # to avoid stupid and difficult to debug mistakes
@@ -98,39 +134,23 @@ class NativeSimulatorAdapter(DeviceAbstract):
         except asyncio.TimeoutError:
             return None
 
-    def _run_simulation(self, timeout: float) -> None:
-        log_command(logger, 'Running command', self.command, level=logging.INFO)
-        try:
-            return_code: int = asyncio.run(
-                self._run_command(timeout=timeout)
-            )
-        except subprocess.SubprocessError as e:
-            logger.error('Running simulation failed due to subprocess error %s', e)
-            self._exc = TwisterRunException(e.args)
-        except FileNotFoundError as e:
-            logger.error(f'Running simulation failed due to file not found: {e.filename}')
-            self._exc = TwisterRunException(f'File not found: {e.filename}')
-        except Exception as e:
-            logger.error('Running simulation failed: %s', e)
-            self._exc = TwisterRunException(e.args)
-        else:
-            if return_code == 0:
-                logger.info('Running simulation finished with return code %s', return_code)
-            else:
-                logger.warning('Running simulation finished with return code %s', return_code)
-        finally:
-            self.queue.put(END_OF_DATA)  # indicate to the other threads that there will be no more data in queue
-
     def disconnect(self):
-        pass
+        pass  # pragma: no cover
 
     def stop(self) -> None:
         """Stop device."""
         self._stop_job = True
         time.sleep(0.1)  # give a time to end while loop in running simulation
         if self._process is not None and self._process.returncode is None:
+            logger.debug('Stopping all running processes for PID %s', self._process.pid)
             # kill subprocess if it is still running
-            os.kill(self._process.pid, signal.SIGINT)
+            for child in psutil.Process(self._process.pid).children(recursive=True):
+                try:
+                    os.kill(child.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+            # kill subprocess if it is still running
+            os.kill(self._process.pid, signal.SIGTERM)
         if self._thread is not None:
             self._thread.join(timeout=1)  # Should end immediately, but just in case we set timeout for 1 sec
         if self._exc:
@@ -146,3 +166,32 @@ class NativeSimulatorAdapter(DeviceAbstract):
                 break
             yield line
             self.queue.task_done()
+
+
+class NativeSimulatorAdapter(SimulatorAdapterBase):
+    """Simulator adapter to run `zephyr.exe` simulation"""
+
+    def generate_command(self, build_dir: Path | str) -> None:
+        """
+        Return command to run.
+
+        :param build_dir: build directory
+        :return: command to run
+        """
+        self.command = [str((Path(build_dir) / 'zephyr' / 'zephyr.exe').resolve())]
+
+
+class CustomSimulatorAdapter(SimulatorAdapterBase):
+
+    def generate_command(self, build_dir: Path | str) -> None:
+        """
+        Return command to run.
+
+        :param build_dir: build directory
+        :return: command to run
+        """
+        if (west := shutil.which('west')) is None:
+            logger.error('west not found')
+            self.command = []
+        else:
+            self.command = [west, 'build', '-d', str(build_dir), '-t', 'run']

--- a/src/twister2/fixtures/common.py
+++ b/src/twister2/fixtures/common.py
@@ -71,11 +71,14 @@ class SetupTestManager:
         return State(True)
 
     def get_device_type(self) -> str:
-        if self.platform.type == 'mcu':
+        if self.platform.simulation != 'na':
+            if self.platform.type == 'qemu':
+                return 'qemu'
+            elif self.platform.type == 'native':
+                return 'native'
+            else:
+                return 'custom'
+        elif self.platform.type == 'mcu':
             return 'hardware'
-        elif self.platform.type == 'native':
-            return 'native'
-        elif self.platform.type == 'qemu':
-            return 'qemu'
         else:
             return ''

--- a/tests/device/data/fifo_mock.py
+++ b/tests/device/data/fifo_mock.py
@@ -76,7 +76,7 @@ class FifoFile:
 
 
 def main():
-    logging.basicConfig(level='DEBUG', filename='fifo_mock.log', filemode='w')
+    logging.basicConfig(level='DEBUG')
     parser = ArgumentParser()
     parser.add_argument('file')
     args = parser.parse_args()

--- a/tests/device/hardware_adapter_test.py
+++ b/tests/device/hardware_adapter_test.py
@@ -43,6 +43,13 @@ def test_if_get_command_returns_proper_string_2(patched_which, device) -> None:
 
 
 @mock.patch('twister2.device.hardware_adapter.shutil.which')
+def test_if_get_command_raise_exception_if_west_is_not_installed(patched_which, device) -> None:
+    patched_which.return_value = None
+    with pytest.raises(TwisterFlashException, match='west not found'):
+        device.generate_command('src')
+
+
+@mock.patch('twister2.device.hardware_adapter.shutil.which')
 def test_if_get_command_returns_proper_string_3(patched_which, device) -> None:
     patched_which.return_value = 'west'
     device.hardware_map.runner = 'nrfjprog'
@@ -105,6 +112,19 @@ def test_if_get_command_returns_proper_string_7(patched_which, device) -> None:
     assert device.command == [
         'west', 'flash', '--skip-rebuild', '--build-dir', 'src', '--runner', 'stm32cubeprogrammer',
         '--tool-opt=sn=p_id'
+    ]
+
+
+@mock.patch('twister2.device.hardware_adapter.shutil.which')
+def test_if_get_command_returns_proper_string_8(patched_which, device) -> None:
+    patched_which.return_value = 'west'
+    device.hardware_map.runner = 'openocd'
+    device.hardware_map.product = 'STLINK-V3'
+    device.generate_command('src')
+    assert isinstance(device.command, list)
+    assert device.command == [
+        'west', 'flash', '--skip-rebuild', '--build-dir', 'src',
+        '--runner', 'openocd', '--', '--cmd-pre-init', 'hla_serial test'
     ]
 
 

--- a/tests/device/qemu_adapter_test.py
+++ b/tests/device/qemu_adapter_test.py
@@ -1,3 +1,5 @@
+import subprocess
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -45,6 +47,14 @@ def test_if_qemu_adapter_raises_exception_file_not_found(device) -> None:
         device.stop()
     assert device._exc is not None
     assert isinstance(device._exc, TwisterRunException)
+
+
+@mock.patch('subprocess.Popen', side_effect=subprocess.SubprocessError(1, 'Exception message'))
+def test_if_qemu_adapter_raises_exception_when_subprocess_raised_an_error(patched_run, device):
+    device.command = ['echo', 'TEST']
+    with pytest.raises(TwisterRunException, match='Exception message'):
+        device.flash_and_run(timeout=0.1)
+        device.stop()
 
 
 def test_if_qemu_adapter_runs_without_errors(resources, twister_config, tmp_path) -> None:

--- a/tests/fixtures/common_test.py
+++ b/tests/fixtures/common_test.py
@@ -1,6 +1,14 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from twister2.fixtures.common import SetupTestManager
+
+
+@pytest.fixture
+def request_mock():
+    instance = MagicMock(pytest.FixtureRequest)
+    return instance
 
 
 @pytest.mark.parametrize(
@@ -16,3 +24,23 @@ from twister2.fixtures.common import SetupTestManager
 def test_if_test_should_be_skipped(build_only, device_testing, runnable, platform_type, expected):
     result = SetupTestManager.should_be_executed(build_only, device_testing, runnable, platform_type)
     assert result.should_run == expected
+
+
+@pytest.mark.parametrize(
+    'spec_type, platform_type, platform_simulation, expected_device',
+    [
+        ('integration', 'qemu', 'qemu', 'qemu'),
+        ('integration', 'native', 'native', 'native'),
+        ('integration', 'sim', 'nsim', 'custom'),
+        ('integration', 'mcu', 'na', 'hardware'),
+    ]
+)
+def test_if_get_device_type_returns_proper_device(
+    request_mock, spec_type, platform_type, platform_simulation, expected_device
+):
+    manager = SetupTestManager(request_mock)
+    manager.specification.type = spec_type
+    manager.platform.type = platform_type
+    manager.platform.simulation = platform_simulation
+
+    assert manager.get_device_type() == expected_device


### PR DESCRIPTION
This PR implements custom simulator adapter for other simulators than zephyr. 

Tested with platform `m2gl025_miv`.
Command which was used:
```sh
pytest samples/hello_world --platform=m2gl025_miv -vvs -o log_cli=true --log-level=INFO
```
Terminal output:
```log
------------------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------------------
DEBUG    asyncio:selector_events.py:54 Using selector: EpollSelector
2023-01-17 12:47:18,542:DEBUG:twister2.device.simulator_adapter: Started subprocess with PID 43113
2023-01-17 12:47:18,642:DEBUG:twister2.log_parser.factory: Get log parser type "console"
2023-01-17 12:47:18,643:INFO:twister2.yaml_test_function: Execution test sample.basic.helloworld[m2gl025_miv] from /home/lufu/workspace/zephyrproject/zephyr/samples/hello_world
2023-01-17 12:47:18,643:DEBUG:twister2.log_parser.console_log_parser: ConsoleLogParser: Parsing output
2023-01-17 12:47:18,922:INFO:twister2.log_parser.console_log_parser: -- west build: running target run
2023-01-17 12:47:19,083:INFO:twister2.log_parser.console_log_parser: [0/1] cd /home/lufu/workspace/zephyrproject/zephyr/twister-out/m2gl025_miv/samples/hello_world/sample.basic.helloworld && /usr/share/renode_portable/renode --disable-xwt --port -2 --pid-file renode.pid -e '$bin=@/home/lufu/workspace/zephyrproject/zephyr/twister-out/m2gl025_miv/samples/hello_world/sample.basic.helloworld/zephyr/zephyr.elf; include @/home/lufu/workspace/zephyrproject/zephyr/boards/riscv/m2gl025_miv/support/m2gl025_miv.resc; s'
2023-01-17 12:47:25,482:INFO:twister2.log_parser.console_log_parser: 12:47:25.4670 [INFO] Loaded monitor commands from: /usr/share/renode_portable/scripts/monitor.py
2023-01-17 12:47:25,563:INFO:twister2.log_parser.console_log_parser: 12:47:25.5628 [INFO] Including script: /home/lufu/workspace/zephyrproject/zephyr/boards/riscv/m2gl025_miv/support/m2gl025_miv.resc
2023-01-17 12:47:25,600:INFO:twister2.log_parser.console_log_parser: 12:47:25.5995 [INFO] System bus created.
2023-01-17 12:47:26,524:INFO:twister2.log_parser.console_log_parser: 12:47:26.5240 [WARNING] At /home/lufu/workspace/zephyrproject/zephyr/boards/riscv/m2gl025_miv/support/m2gl025_miv.repl:6:5: updating constructors of the entry declared earlier.
2023-01-17 12:47:26,525:INFO:twister2.log_parser.console_log_parser: 12:47:26.5246 [WARNING] At /home/lufu/workspace/zephyrproject/zephyr/boards/riscv/m2gl025_miv/support/m2gl025_miv.repl:9:5: updating constructors of the entry declared earlier.
2023-01-17 12:47:26,525:INFO:twister2.log_parser.console_log_parser: 12:47:26.5252 [WARNING] At /home/lufu/workspace/zephyrproject/zephyr/boards/riscv/m2gl025_miv/support/m2gl025_miv.repl:12:5: updating constructors of the entry declared earlier.
2023-01-17 12:47:26,526:INFO:twister2.log_parser.console_log_parser: 12:47:26.5256 [WARNING] At /home/lufu/workspace/zephyrproject/zephyr/boards/riscv/m2gl025_miv/support/m2gl025_miv.repl:15:5: updating constructors of the entry declared earlier.
2023-01-17 12:47:27,638:INFO:twister2.log_parser.console_log_parser: 12:47:27.6373 [INFO] sysbus: Loading segment of 13664 bytes length at 0x80000000.
2023-01-17 12:47:27,659:INFO:twister2.log_parser.console_log_parser: 12:47:27.6593 [INFO] sysbus: Loading segment of 18 bytes length at 0x80003560.
2023-01-17 12:47:27,660:INFO:twister2.log_parser.console_log_parser: 12:47:27.6598 [INFO] sysbus: Loading segment of 4 bytes length at 0x80003572.
2023-01-17 12:47:27,661:INFO:twister2.log_parser.console_log_parser: 12:47:27.6603 [INFO] sysbus: Loading segment of 3952 bytes length at 0x80040000.
2023-01-17 12:47:27,705:INFO:twister2.log_parser.console_log_parser: 12:47:27.7052 [INFO] cpu: Setting PC value to 0x80000000.
2023-01-17 12:47:27,826:INFO:twister2.log_parser.console_log_parser: 12:47:27.8260 [INFO] Mi-V: Machine started.
2023-01-17 12:47:27,942:INFO:twister2.log_parser.console_log_parser: 12:47:27.9421 [WARNING] plic: Unhandled write to offset 0x200000, value 0x0.
2023-01-17 12:47:27,957:INFO:twister2.log_parser.console_log_parser: 12:47:27.9573 [WARNING] uart: Unhandled write to offset 0xC. Unhandled bits: [0] when writing value 0x1. Tags: BIT8 (0x1).
2023-01-17 12:47:27,978:INFO:twister2.log_parser.console_log_parser: 12:47:27.9781 [INFO] uart: [host: 1.07s (+1.07s)|virt: 1.3ms (+1.3ms)] *** Booting Zephyr OS build zephyr-v3.2.0-3404-g6cbb3f5eece3 ***
2023-01-17 12:47:27,983:INFO:twister2.log_parser.console_log_parser: 12:47:27.9825 [INFO] uart: [host: 1.08s (+4.56ms)|virt: 1.7ms (+0.4ms)] Hello World! m2gl025_miv
2023-01-17 12:47:27,983:INFO:twister2.log_parser.console_log_parser: Console parser found expected lines
PASSED2023-01-17 12:47:28,102:DEBUG:twister2.device.simulator_adapter: Stopping all running processes for PID 43113
2023-01-17 12:47:28,120:INFO:twister2.device.simulator_adapter: Running simulation stopped interrupted by user

================================================================================================================== 1 passed in 9.65s ==================================================================================================================
```
Signed-off-by: Fundakowski, Lukasz <lukasz.fundakowski@nordicsemi.no>