### PR TITLE
Add temporary stub for filter option

### DIFF
--- a/src/twister2/specification_processor.py
+++ b/src/twister2/specification_processor.py
@@ -194,6 +194,7 @@ def should_be_skip(test_spec: YamlTestSpecification, platform: PlatformSpecifica
         should_skip_for_pytest_harness(test_spec, platform),
         should_skip_for_tag(test_spec, platform),
         should_skip_for_toolchain(test_spec, platform),
+        should_skip_for_filter_option(test_spec, platform),
     ]):
         return True
     return False
@@ -277,6 +278,18 @@ def should_skip_for_depends_on(test_spec: YamlTestSpecification, platform: Platf
     if not_supported_dependencies:
         reason = f'"{_join_strings(not_supported_dependencies)}" not occur in the "supported" section in the ' \
                  'platform definition yaml'
+        _log_test_skip(test_spec, platform, reason)
+        return True
+    return False
+
+
+def should_skip_for_filter_option(test_spec: YamlTestSpecification, platform: PlatformSpecification) -> bool:
+    """
+    TODO: This function should be removed when Kconfig and DTS filtering will be implemented correctly:
+    https://github.com/zephyrproject-rtos/twister/issues/14
+    """
+    if test_spec.filter != '':
+        reason = 'Kconfig and DTS filtering from yaml "filter option" is not implemented yet'
         _log_test_skip(test_spec, platform, reason)
         return True
     return False

--- a/tests/data/tests/common/testcase.yaml
+++ b/tests/data/tests/common/testcase.yaml
@@ -2,14 +2,12 @@ common:
   tags: kernel posix
   extra_configs:
       - CONFIG_POSIX_API=y
-  filter: TOOLCHAIN_HAS_NEWLIB == 1
   min_ram: 32
 tests:
   xyz.common_merge_1:
     tags: picolibc
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
-    filter: CONFIG_PICOLIBC_SUPPORTED
     min_ram: 64
   xyz.common_merge_2:
     tags: arm

--- a/tests/yaml_file_test.py
+++ b/tests/yaml_file_test.py
@@ -7,10 +7,8 @@ def test_if_can_read_test_specifications_from_yaml_common(twister_config, resour
         if spec.original_name == 'xyz.common_merge_1':
             assert spec.tags == {'kernel', 'posix', 'picolibc'}
             assert spec.extra_configs == ['CONFIG_NEWLIB_LIBC=y', 'CONFIG_POSIX_API=y']
-            assert spec.filter == '(CONFIG_PICOLIBC_SUPPORTED) and (TOOLCHAIN_HAS_NEWLIB == 1)'
             assert spec.min_ram == 64
         elif spec.original_name == 'xyz.common_merge_2':
             assert spec.tags == {'kernel', 'posix', 'arm'}
             assert spec.extra_configs == ['CONFIG_POSIX_API=y']
-            assert spec.filter == 'TOOLCHAIN_HAS_NEWLIB == 1'
             assert spec.min_ram == 32


### PR DESCRIPTION
Until Kconfg and DTS filtration will be not implemented then all tests with filter option in yaml test definition should be skipped.

Can be tested by:
```
pytest -vv -s --log-level=INFO -o log_cli=true --clear=archive --results-json=twister-out/results.json --platform=qemu_cortex_m3 samples/hello_world, samples/userspace/hello_world_user tests/drivers/sensor/sbs_gauge samples/arch/smp/pi 
```
Only one test should be passed:
`samples/hello_world/sample.yaml::sample.basic.helloworld[qemu_cortex_m3]`
And three next should be skipped (visible only in `twister-out/testcases_creation.log` file):
`samples/userspace/hello_world_user/sample.yaml::sample.helloworld[qemu_cortex_m3]`
`tests/drivers/sensor/sbs_gauge/testcase.yaml::drivers.sbs_gauge[qemu_cortex_m3]`
`samples/arch/smp/pi/sample.yaml::sample.smp.pi[qemu_cortex_m3]`