### PR TITLE
Add KConfig and DTS filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ twister-out*
 
 # Sphinx documentation
 docs/.apidoc/
+
+# KConfig DTS filtration
+*parsetab.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,6 @@ flake8
 isort
 mypy==0.991
 pytest-cov
+tox
 types-PyYAML
 types-tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 filelock==3.9.0
 marshmallow==3.19.0
+ply==3.11
 psutil==5.9.4
 pyserial==3.5
 pytest==7.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ package_dir =
 install_requires =
     filelock
     marshmallow
+    ply
     psutil
     pytest>=7.0.0
     pytest-subtests>=0.7.0
@@ -51,6 +52,10 @@ ignore =
 per-file-ignores =
     # imported but unused
     __init__.py: F401
+exclude =
+	parsetab.py
+	# TODO: remove after file is refactored
+	expr_parser.py
 
 [isort]
 profile = black
@@ -64,3 +69,4 @@ line_length = 88
 
 [mypy]
 ignore_missing_imports = True
+exclude = parsetab.py

--- a/src/twister2/builder/build_filter_processor.py
+++ b/src/twister2/builder/build_filter_processor.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+
+from twister2.builder.builder_abstract import BuildConfig, BuilderAbstract
+from twister2.exceptions import TwisterBuildFiltrationException
+from twister2.kconfig_dts_filter.kconfig_dts_filter import KconfigDtsFilter
+
+logger = logging.getLogger(__name__)
+
+
+class BuildFilterProcessor:
+    """Run additional setup before actual build is triggered."""
+
+    def __init__(self, builder: BuilderAbstract) -> None:
+        self.builder = builder
+
+    def process(self) -> None:
+        """Run build with cmake_helper flag enabled."""
+        self.builder.build(True)
+        self._apply_kconfig_and_dts_filtration(self.builder.build_config)
+
+    def _apply_kconfig_and_dts_filtration(self, build_config: BuildConfig) -> None:
+        kconfig_dts_filter = KconfigDtsFilter(
+            build_config.zephyr_base,
+            build_config.build_dir,
+            build_config.platform_arch,
+            build_config.platform_name,
+            build_config.kconfig_dts_filter
+        )
+        result: bool = kconfig_dts_filter.filter()
+        if result is False:
+            raise TwisterBuildFiltrationException(f'{build_config.source_dir}')

--- a/src/twister2/builder/builder_abstract.py
+++ b/src/twister2/builder/builder_abstract.py
@@ -10,11 +10,15 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class BuildConfig:
+    """Class store all information required by builder to build a source code."""
     zephyr_base: str | Path
     source_dir: str | Path
+    output_dir: str | Path
     build_dir: str | Path
-    platform: str
+    platform_arch: str
+    platform_name: str
     scenario: str
+    kconfig_dts_filter: str
     extra_configs: list[str] = field(default_factory=list)
     extra_args_spec: list[str] = field(default_factory=list)
     extra_args_cli: list[str] = field(default_factory=list)
@@ -24,13 +28,57 @@ class BuildConfig:
 class BuilderAbstract(abc.ABC):
     """Base class for builders."""
 
+    def __init__(self, build_config: BuildConfig) -> None:
+        self.build_config = build_config
+
     def __repr__(self):
         return f'{self.__class__.__name__}()'
 
     @abc.abstractmethod
-    def build(self, build_config: BuildConfig) -> None:
+    def build(self, cmake_helper: bool = False) -> None:
         """
         Build Zephyr application.
 
-        :param build_config: build configuration
+        :param cmake_helper: if True only CMake package helper should be run, without full building
         """
+
+    def _prepare_cmake_args(self, build_config: BuildConfig) -> list[str]:
+        """
+        "extra_configs" and "extra_args" which came from .yaml file are unpacked
+        and parsed here to avoid limitation of west "--test-item" option which
+        works properly only with testcase.yaml and sample.yaml files.
+        "--test-item" option doesn't work with unorthodox .yaml files like
+        testspec.yaml file.
+        """
+        cmake_args = []
+
+        ldflags = '-Wl,--fatal-warnings'
+        cflags = '-Werror'
+        aflags = '-Werror -Wa,--fatal-warnings'
+        gen_defines_args = '--edtlib-Werror'
+
+        cmake_args += [
+            f'-DEXTRA_CFLAGS={cflags}',
+            f'-DEXTRA_AFLAGS={aflags}',
+            f'-DEXTRA_LDFLAGS={ldflags}',
+            f'-DEXTRA_GEN_DEFINES_ARGS={gen_defines_args}',
+        ]
+
+        cmake_args += (self._prepare_extra_configs(build_config.extra_configs))
+        cmake_args += (self._prepare_args(build_config.extra_args_spec))
+        cmake_args += (self._prepare_args(build_config.extra_args_cli))
+
+        return cmake_args
+
+    @staticmethod
+    def _prepare_args(args: list[str]) -> list[str]:
+        return ['-D{}'.format(arg.replace('"', '')) for arg in args]
+
+    @staticmethod
+    def _prepare_extra_configs(args: list[str]) -> list[str]:
+        return ['-D{}'.format(arg) for arg in args]
+
+    @staticmethod
+    def _log_output(output: bytes, level: int) -> None:
+        for line in output.decode().split('\n'):
+            logger.log(level, line)

--- a/src/twister2/builder/cmake_builder.py
+++ b/src/twister2/builder/cmake_builder.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+
+from twister2.builder.builder_abstract import BuilderAbstract
+from twister2.exceptions import TwisterBuildException
+from twister2.helper import log_command
+
+logger = logging.getLogger(__name__)
+
+
+class CmakeBuilder(BuilderAbstract):
+    """Build source code using `cmake`"""
+
+    def build(self, cmake_helper: bool = False) -> None:
+        """
+        Build Zephyr application with `cmake`.
+
+        :param cmake_helper: if True only CMake package helper should be run, without full building
+        """
+        logger.info('Building Zephyr application')
+        self.run_cmake(cmake_helper)
+        if cmake_helper:
+            return
+        self.run_build_generator()
+
+    def run_cmake(self, cmake_helper: bool = False) -> None:
+        cmake = self._get_cmake()
+
+        command = [
+            cmake,
+            f'-S{self.build_config.source_dir}',
+            f'-B{self.build_config.build_dir}',
+            f'-DBOARD={self.build_config.platform_name}'
+        ]
+
+        if cmake_args := self._prepare_cmake_args(self.build_config):
+            command.extend(cmake_args)
+
+        if cmake_helper:
+            command.extend(
+                [
+                    '-DMODULES=dts,kconfig',
+                    f'-P{self.build_config.zephyr_base}/cmake/package_helper.cmake',
+                ]
+            )
+
+        log_command(logger, 'Cmake command', command, level=logging.INFO)
+        self._run_command_in_subprocess(command, action='Cmake')
+
+    def run_build_generator(self) -> None:
+        cmake = self._get_cmake()
+        command: list[str] = [cmake, '--build', str(self.build_config.build_dir)]
+        log_command(logger, 'Build command', command, level=logging.INFO)
+        self._run_command_in_subprocess(command, action='building')
+
+    def _run_command_in_subprocess(self, command: list[str], action: str) -> None:
+        try:
+            process = subprocess.run(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.exception(
+                'An exception has been raised for %s: %s for %s',
+                action, self.build_config.source_dir, self.build_config.platform_name
+            )
+            raise TwisterBuildException('CMake error') from e
+        else:
+            if process.returncode == 0:
+                self._log_output(process.stdout, logging.DEBUG)
+                logger.info(
+                    'Finished running CMake on %s for %s',
+                    self.build_config.source_dir, self.build_config.platform_name
+                )
+            else:
+                self._log_output(process.stdout, logging.INFO)
+                msg = (
+                    f'Failed running CMake {self.build_config.source_dir} '
+                    f'for platform: {self.build_config.platform_name}'
+                )
+                logger.error(msg)
+                raise TwisterBuildException(msg)
+
+    @staticmethod
+    def _get_cmake() -> str:
+        if (cmake := shutil.which('cmake')) is None:
+            raise TwisterBuildException('cmake not found')
+        return cmake

--- a/src/twister2/builder/factory.py
+++ b/src/twister2/builder/factory.py
@@ -4,6 +4,7 @@ import logging
 from typing import Type
 
 from twister2.builder.builder_abstract import BuilderAbstract
+from twister2.builder.cmake_builder import CmakeBuilder
 from twister2.builder.west_builder import WestBuilder
 
 logger = logging.getLogger(__name__)
@@ -19,18 +20,31 @@ class BuilderFactory:
             cls._builders[name] = klass
 
     @classmethod
-    def get_builder(cls, name: str) -> BuilderAbstract:
+    def get_builder(cls, name: str) -> Type[BuilderAbstract]:
         """
-        Return builder.
+        Return builder class.
 
         :param name: builder name
         :return: builder instance
         """
         try:
-            return cls._builders[name]()
+            return cls._builders[name]
         except KeyError as e:
-            logger.exception('There is not builder with name: %s', name)
-            raise KeyError(f'Builder "{name}" does not exist') from e
+            logger.exception('There is not builder class with name: %s', name)
+            raise KeyError(f'Builder class "{name}" does not exist') from e
+
+    @classmethod
+    def create_instance(cls, name, *args, **kwargs) -> BuilderAbstract:
+        """
+        Create new instance of builder.
+
+        :param name: builder name
+        :param args: unnamed arguments for builder class
+        :param kwargs: named arguments for builder class
+        :return: new builder instance
+        """
+        return cls.get_builder(name)(*args, **kwargs)
 
 
+BuilderFactory.register_builder_class('cmake', CmakeBuilder)
 BuilderFactory.register_builder_class('west', WestBuilder)

--- a/src/twister2/builder/west_builder.py
+++ b/src/twister2/builder/west_builder.py
@@ -13,8 +13,9 @@ logger = logging.getLogger(__name__)
 
 
 class WestBuilder(BuilderAbstract):
+    """Build source code using `west`"""
 
-    def build(self, build_config: BuildConfig) -> None:
+    def build(self, cmake_helper: bool = False) -> None:
         """
         Build Zephyr application with `west`.
         """
@@ -24,13 +25,13 @@ class WestBuilder(BuilderAbstract):
         command = [
             west,
             'build',
-            str(build_config.source_dir),
+            str(self.build_config.source_dir),
             '--pristine', 'always',
-            '--board', build_config.platform,
+            '--board', self.build_config.platform_name,
         ]
-        if build_config.build_dir:
-            command.extend(['--build-dir', str(build_config.build_dir)])
-        if cmake_args := self._prepare_cmake_args(build_config):
+        if self.build_config.build_dir:
+            command.extend(['--build-dir', str(self.build_config.build_dir)])
+        if cmake_args := self._prepare_cmake_args(self.build_config):
             command.extend(['--'] + cmake_args)
 
         logger.info('Building Zephyr application')
@@ -44,44 +45,23 @@ class WestBuilder(BuilderAbstract):
         except subprocess.CalledProcessError as e:
             logger.exception(
                 'An exception has been raised for build subprocess: %s for %s',
-                build_config.source_dir, build_config.platform
+                self.build_config.source_dir, self.build_config.platform_name
             )
             raise TwisterBuildException('Building error') from e
         else:
             if process.returncode == 0:
                 self._log_output(process.stdout, logging.DEBUG)
-                logger.info('Finished building %s for %s', build_config.source_dir, build_config.platform)
+                logger.info(
+                    'Finished building %s for %s',
+                    self.build_config.source_dir, self.build_config.platform_name
+                )
             else:
-                self._handle_build_failure(build_config, process.stdout)
-
-    def _prepare_cmake_args(self, build_config: BuildConfig) -> list[str]:
-        """
-        "extra_configs" and "extra_args" which came from .yaml file are unpacked
-        and parsed here to avoid limitation of west "--test-item" option which
-        works properly only with testcase.yaml and sample.yaml files.
-        "--test-item" option doesn't work with unorthodox .yaml files like
-        testspec.yaml file.
-        """
-        cmake_args = []
-
-        cmake_args += (self._prepare_extra_configs(build_config.extra_configs))
-        cmake_args += (self._prepare_args(build_config.extra_args_spec))
-        cmake_args += (self._prepare_args(build_config.extra_args_cli))
-
-        return cmake_args
-
-    @staticmethod
-    def _prepare_args(args: list[str]) -> list[str]:
-        return ['-D{}'.format(arg.replace('"', '')) for arg in args]
-
-    @staticmethod
-    def _prepare_extra_configs(args: list[str]) -> list[str]:
-        return ['-D{}'.format(arg) for arg in args]
+                self._handle_build_failure(self.build_config, process.stdout)
 
     def _handle_build_failure(self, build_config: BuildConfig, stdout_output: bytes):
         self._log_output(stdout_output, logging.INFO)
         self._check_memory_overflow(build_config, stdout_output)
-        msg = f'Failed building {build_config.source_dir} for platform: {build_config.platform}'
+        msg = f'Failed building {build_config.source_dir} for platform: {build_config.platform_name}'
         logger.error(msg)
         raise TwisterBuildException(msg)
 
@@ -93,15 +73,10 @@ class WestBuilder(BuilderAbstract):
         memory_overflow_found = re.findall(memory_overflow_pattern, build_output)
         if memory_overflow_found:
             msg = f'Memory overflow during building {build_config.source_dir} for platform: ' \
-                  f'{build_config.platform}'
+                  f'{build_config.platform_name}'
             raise TwisterMemoryOverflowException(msg)
         imgtool_overflow_found = re.findall(imgtool_overflow_pattern, build_output)
         if imgtool_overflow_found:
             msg = f'Imgtool memory overflow during building {build_config.source_dir} for platform: ' \
-                  f'{build_config.platform}'
+                  f'{build_config.platform_name}'
             raise TwisterMemoryOverflowException(msg)
-
-    @staticmethod
-    def _log_output(output: bytes, level: int) -> None:
-        for line in output.decode().split('\n'):
-            logger.log(level, line)

--- a/src/twister2/exceptions.py
+++ b/src/twister2/exceptions.py
@@ -3,23 +3,15 @@ class TwisterException(Exception):
 
 
 class TwisterConfigurationException(TwisterException):
-    """Exception for all configuration errors."""
-
-
-class YamlException(TwisterException):
-    """Custom exception for error reporting."""
+    """Raised when any error appeared for plugin configuration."""
 
 
 class TwisterFatalError(TwisterException):
-    """Twister fatal error exception."""
-
-
-class ProjectExecutionFailed(TwisterException):
-    """Project execution failed exception."""
+    """Raised when Zephyr fatal error was found in parsed output from Zephyr."""
 
 
 class TwisterBuildException(TwisterException):
-    """Any exception during building."""
+    """Raised when any error appeared during building."""
 
 
 class TwisterBuildSkipException(TwisterException):
@@ -31,16 +23,20 @@ class TwisterMemoryOverflowException(TwisterException):
 
 
 class TwisterFlashException(TwisterException):
-    """Any exception during flashing."""
+    """Raised when any error appeared during flashing."""
 
 
 class TwisterRunException(TwisterException):
-    """Any exception during executing."""
+    """Raised when any error appeared during execution."""
 
 
 class TwisterTimeoutExpired(TwisterException):
-    """Subprocess ended due to timeout."""
+    """Raised when subprocess ended due to timeout."""
 
 
 class TwisterHarnessParserException(TwisterException):
-    """Harness parser exception."""
+    """Raised when any error appeared in Harness parser."""
+
+
+class TwisterBuildFiltrationException(TwisterException):
+    """Raised when Kconfig or DTS filtration should be applied for test."""

--- a/src/twister2/fixtures/builder.py
+++ b/src/twister2/fixtures/builder.py
@@ -1,16 +1,21 @@
 """
 Pytest fixture for building hex files.
 """
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import Generator
 
 import pytest
 
+from twister2.builder.build_filter_processor import BuildFilterProcessor
 from twister2.builder.build_manager import BuildManager
 from twister2.builder.builder_abstract import BuildConfig, BuilderAbstract
+from twister2.builder.cmake_builder import CmakeBuilder
 from twister2.builder.factory import BuilderFactory
 from twister2.exceptions import (
+    TwisterBuildFiltrationException,
     TwisterBuildSkipException,
     TwisterMemoryOverflowException,
 )
@@ -25,13 +30,11 @@ def fixture_build_manager(
         request: pytest.FixtureRequest, setup_manager: SetupTestManager
 ) -> Generator[BuildManager, None, None]:
     """Build manager"""
+    platform = setup_manager.platform
     spec = setup_manager.specification
     twister_config = setup_manager.twister_config
 
     spec.output_dir = Path(twister_config.output_dir).resolve()
-
-    builder_type: str = request.config.option.builder
-    builder = BuilderFactory.get_builder(builder_type)
 
     if setup_manager.get_device_type() == 'qemu':
         spec.extra_args.append(f'QEMU_PIPE={spec.fifo_file}')
@@ -39,15 +42,25 @@ def fixture_build_manager(
     build_config = BuildConfig(
         zephyr_base=setup_manager.twister_config.zephyr_base,
         source_dir=spec.source_dir,
-        platform=spec.platform,
+        platform_arch=platform.arch,
+        platform_name=platform.identifier,
         build_dir=spec.build_dir,
+        output_dir=request.config.option.output_dir,
         scenario=spec.scenario,
         extra_configs=spec.extra_configs,
         extra_args_spec=spec.extra_args,
         extra_args_cli=twister_config.extra_args_cli,
-        overflow_as_errors=twister_config.overflow_as_errors
+        overflow_as_errors=twister_config.overflow_as_errors,
+        kconfig_dts_filter=spec.filter,
     )
-    build_manager = BuildManager(request.config.option.output_dir, build_config, builder)
+    if spec.filter:
+        build_filer_processor = BuildFilterProcessor(CmakeBuilder(build_config))
+    else:
+        build_filer_processor = None
+
+    builder_type: str = request.config.option.builder
+    builder = BuilderFactory.create_instance(builder_type, build_config)
+    build_manager = BuildManager(build_config, builder, build_filer_processor)
     yield build_manager
 
 
@@ -67,6 +80,8 @@ def fixture_builder(
             pytest.skip(str(overflow_exception))
     except TwisterBuildSkipException as skip_exception:
         pytest.skip(str(skip_exception))
+    except TwisterBuildFiltrationException:
+        pytest.skip('Kconfig or dts filtration')
 
     if not isinstance(request.function, YamlTestCase):
         # skip regular tests

--- a/src/twister2/generate_tests_plugin.py
+++ b/src/twister2/generate_tests_plugin.py
@@ -66,7 +66,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
         platform for platform in twister_config.platforms
         if platform.identifier in twister_config.selected_platforms
     ]
-    spec_file_path: Path = Path(metafunc.definition.fspath.dirname) / TEST_SPEC_FILE_NAME
+    spec_file_path: Path = Path(metafunc.definition.fspath.dirname) / TEST_SPEC_FILE_NAME  # type: ignore[attr-defined]
     scenarios = get_scenarios_from_fixture(metafunc)
     assert spec_file_path.exists(), f'There is no specification file for the test: {spec_file_path}'
     if not scenarios:

--- a/src/twister2/kconfig_dts_filter/cmakecache.py
+++ b/src/twister2/kconfig_dts_filter/cmakecache.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# vim: set syntax=python ts=4 :
+#
+# Copyright (c) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+from collections import OrderedDict
+
+
+class CMakeCacheEntry:
+    '''Represents a CMake cache entry.
+
+    This class understands the type system in a CMakeCache.txt, and
+    converts the following cache types to Python types:
+
+    Cache Type    Python type
+    ----------    -------------------------------------------
+    FILEPATH      str
+    PATH          str
+    STRING        str OR list of str (if ';' is in the value)
+    BOOL          bool
+    INTERNAL      str OR list of str (if ';' is in the value)
+    ----------    -------------------------------------------
+    '''
+
+    # Regular expression for a cache entry.
+    #
+    # CMake variable names can include escape characters, allowing a
+    # wider set of names than is easy to match with a regular
+    # expression. To be permissive here, use a non-greedy match up to
+    # the first colon (':'). This breaks if the variable name has a
+    # colon inside, but it's good enough.
+    CACHE_ENTRY = re.compile(
+        r'''(?P<name>.*?)                               # name
+         :(?P<type>FILEPATH|PATH|STRING|BOOL|INTERNAL)  # type
+         =(?P<value>.*)                                 # value
+        ''', re.X)
+
+    @classmethod
+    def _to_bool(cls, val):
+        # Convert a CMake BOOL string into a Python bool.
+        #
+        #   "True if the constant is 1, ON, YES, TRUE, Y, or a
+        #   non-zero number. False if the constant is 0, OFF, NO,
+        #   FALSE, N, IGNORE, NOTFOUND, the empty string, or ends in
+        #   the suffix -NOTFOUND. Named boolean constants are
+        #   case-insensitive. If the argument is not one of these
+        #   constants, it is treated as a variable."
+        #
+        # https://cmake.org/cmake/help/v3.0/command/if.html
+        val = val.upper()
+        if val in ('ON', 'YES', 'TRUE', 'Y'):
+            return 1
+        elif val in ('OFF', 'NO', 'FALSE', 'N', 'IGNORE', 'NOTFOUND', ''):
+            return 0
+        elif val.endswith('-NOTFOUND'):
+            return 0
+        else:
+            try:
+                v = int(val)
+                return v != 0
+            except ValueError as exc:
+                raise ValueError('invalid bool {}'.format(val)) from exc
+
+    @classmethod
+    def from_line(cls, line, line_no):
+        # Comments can only occur at the beginning of a line.
+        # (The value of an entry could contain a comment character).
+        if line.startswith('//') or line.startswith('#'):
+            return None
+
+        # Whitespace-only lines do not contain cache entries.
+        if not line.strip():
+            return None
+
+        m = cls.CACHE_ENTRY.match(line)
+        if not m:
+            return None
+
+        name, type_, value = (m.group(g) for g in ('name', 'type', 'value'))
+        if type_ == 'BOOL':
+            try:
+                value = cls._to_bool(value)
+            except ValueError as exc:
+                args = exc.args + ('on line {}: {}'.format(line_no, line),)
+                raise ValueError(args) from exc
+        elif type_ in ['STRING', 'INTERNAL']:
+            # If the value is a CMake list (i.e. is a string which
+            # contains a ';'), convert to a Python list.
+            if ';' in value:
+                value = value.split(';')
+
+        return CMakeCacheEntry(name, value)
+
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+    def __str__(self):
+        fmt = 'CMakeCacheEntry(name={}, value={})'
+        return fmt.format(self.name, self.value)
+
+
+class CMakeCache:
+    '''Parses and represents a CMake cache file.'''
+
+    @staticmethod
+    def from_file(cache_file):
+        return CMakeCache(cache_file)
+
+    def __init__(self, cache_file):
+        self.cache_file = cache_file
+        self.load(cache_file)
+
+    def load(self, cache_file):
+        entries = []
+        with open(cache_file, 'r') as cache:
+            for line_no, line in enumerate(cache):
+                entry = CMakeCacheEntry.from_line(line, line_no)
+                if entry:
+                    entries.append(entry)
+        self._entries = OrderedDict((e.name, e) for e in entries)
+
+    def get(self, name, default=None):
+        entry = self._entries.get(name)
+        if entry is not None:
+            return entry.value
+        else:
+            return default
+
+    def get_list(self, name, default=None):
+        if default is None:
+            default = []
+        entry = self._entries.get(name)
+        if entry is not None:
+            value = entry.value
+            if isinstance(value, list):
+                return value
+            elif isinstance(value, str):
+                return [value] if value else []
+            else:
+                msg = 'invalid value {} type {}'
+                raise RuntimeError(msg.format(value, type(value)))
+        else:
+            return default
+
+    def __contains__(self, name):
+        return name in self._entries
+
+    def __getitem__(self, name):
+        return self._entries[name].value
+
+    def __setitem__(self, name, entry):
+        if not isinstance(entry, CMakeCacheEntry):
+            msg = 'improper type {} for value {}, expecting CMakeCacheEntry'
+            raise TypeError(msg.format(type(entry), entry))
+        self._entries[name] = entry
+
+    def __delitem__(self, name):
+        del self._entries[name]
+
+    def __iter__(self):
+        return iter(self._entries.values())

--- a/src/twister2/kconfig_dts_filter/expr_parser.py
+++ b/src/twister2/kconfig_dts_filter/expr_parser.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2016 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import logging
+import os
+import re
+import sys
+import threading
+
+try:
+    import ply.lex as lex
+    import ply.yacc as yacc
+except ImportError:
+    sys.exit('PLY library for Python 3 not installed.\n'
+             "Please install the ply package using your workstation's\n"
+             "package manager or the 'pip' tool.")
+
+_logger = logging.getLogger('twister')
+
+reserved = {
+    'and' : 'AND',
+    'or' : 'OR',
+    'not' : 'NOT',
+    'in' : 'IN',
+}
+
+tokens = [
+    'HEX',
+    'STR',
+    'INTEGER',
+    'EQUALS',
+    'NOTEQUALS',
+    'LT',
+    'GT',
+    'LTEQ',
+    'GTEQ',
+    'OPAREN',
+    'CPAREN',
+    'OBRACKET',
+    'CBRACKET',
+    'COMMA',
+    'SYMBOL',
+    'COLON',
+] + list(reserved.values())
+
+def t_HEX(t):
+    r'0x[0-9a-fA-F]+'
+    t.value = str(int(t.value, 16))
+    return t
+
+def t_INTEGER(t):
+    r'\d+'
+    t.value = str(int(t.value))
+    return t
+
+def t_STR(t):
+    r'\"([^\\\n]|(\\.))*?\"|\'([^\\\n]|(\\.))*?\''
+    # nip off the quotation marks
+    t.value = t.value[1:-1]
+    return t
+
+t_EQUALS = r'=='
+
+t_NOTEQUALS = r'!='
+
+t_LT = r'<'
+
+t_GT = r'>'
+
+t_LTEQ = r'<='
+
+t_GTEQ = r'>='
+
+t_OPAREN = r'[(]'
+
+t_CPAREN = r'[)]'
+
+t_OBRACKET = r'\['
+
+t_CBRACKET = r'\]'
+
+t_COMMA = r','
+
+t_COLON = ':'
+
+def t_SYMBOL(t):
+    r'[A-Za-z_][0-9A-Za-z_]*'
+    t.type = reserved.get(t.value, 'SYMBOL')
+    return t
+
+t_ignore = ' \t\n'
+
+def t_error(t):
+    raise SyntaxError("Unexpected token '%s'" % t.value)
+
+lex.lex()
+
+precedence = (
+    ('left', 'OR'),
+    ('left', 'AND'),
+    ('right', 'NOT'),
+    ('nonassoc', 'EQUALS', 'NOTEQUALS', 'GT', 'LT', 'GTEQ', 'LTEQ', 'IN'),
+)
+
+def p_expr_or(p):
+    'expr : expr OR expr'
+    p[0] = ('or', p[1], p[3])
+
+def p_expr_and(p):
+    'expr : expr AND expr'
+    p[0] = ('and', p[1], p[3])
+
+def p_expr_not(p):
+    'expr : NOT expr'
+    p[0] = ('not', p[2])
+
+def p_expr_parens(p):
+    'expr : OPAREN expr CPAREN'
+    p[0] = p[2]
+
+def p_expr_eval(p):
+    """expr : SYMBOL EQUALS const
+            | SYMBOL NOTEQUALS const
+            | SYMBOL GT number
+            | SYMBOL LT number
+            | SYMBOL GTEQ number
+            | SYMBOL LTEQ number
+            | SYMBOL IN list
+            | SYMBOL COLON STR"""
+    p[0] = (p[2], p[1], p[3])
+
+def p_expr_single(p):
+    """expr : SYMBOL"""
+    p[0] = ('exists', p[1])
+
+def p_func(p):
+    """expr : SYMBOL OPAREN arg_intr CPAREN"""
+    p[0] = [p[1]]
+    p[0].append(p[3])
+
+def p_arg_intr_single(p):
+    """arg_intr : const"""
+    p[0] = [p[1]]
+
+def p_arg_intr_mult(p):
+    """arg_intr : arg_intr COMMA const"""
+    p[0] = copy.copy(p[1])
+    p[0].append(p[3])
+
+def p_list(p):
+    """list : OBRACKET list_intr CBRACKET"""
+    p[0] = p[2]
+
+def p_list_intr_single(p):
+    """list_intr : const"""
+    p[0] = [p[1]]
+
+def p_list_intr_mult(p):
+    """list_intr : list_intr COMMA const"""
+    p[0] = copy.copy(p[1])
+    p[0].append(p[3])
+
+def p_const(p):
+    """const : STR
+             | number"""
+    p[0] = p[1]
+
+def p_number(p):
+    """number : INTEGER
+              | HEX"""
+    p[0] = p[1]
+
+def p_error(p):
+    if p:
+        raise SyntaxError("Unexpected token '%s'" % p.value)
+    else:
+        raise SyntaxError('Unexpected end of expression')
+
+if 'PARSETAB_DIR' not in os.environ:
+    parser = yacc.yacc(debug=0)
+else:
+    parser = yacc.yacc(debug=0, outputdir=os.environ['PARSETAB_DIR'])
+
+def ast_sym(ast, env):
+    if ast in env:
+        return str(env[ast])
+    return ''
+
+def ast_sym_int(ast, env):
+    if ast in env:
+        v = env[ast]
+        if v.startswith('0x') or v.startswith('0X'):
+            return int(v, 16)
+        else:
+            return int(v, 10)
+    return 0
+
+def ast_expr(ast, env, edt):
+    if ast[0] == 'not':
+        return not ast_expr(ast[1], env, edt)
+    elif ast[0] == 'or':
+        return ast_expr(ast[1], env, edt) or ast_expr(ast[2], env, edt)
+    elif ast[0] == 'and':
+        return ast_expr(ast[1], env, edt) and ast_expr(ast[2], env, edt)
+    elif ast[0] == '==':
+        return ast_sym(ast[1], env) == ast[2]
+    elif ast[0] == '!=':
+        return ast_sym(ast[1], env) != ast[2]
+    elif ast[0] == '>':
+        return ast_sym_int(ast[1], env) > int(ast[2])
+    elif ast[0] == '<':
+        return ast_sym_int(ast[1], env) < int(ast[2])
+    elif ast[0] == '>=':
+        return ast_sym_int(ast[1], env) >= int(ast[2])
+    elif ast[0] == '<=':
+        return ast_sym_int(ast[1], env) <= int(ast[2])
+    elif ast[0] == 'in':
+        return ast_sym(ast[1], env) in ast[2]
+    elif ast[0] == 'exists':
+        return bool(ast_sym(ast[1], env))
+    elif ast[0] == ':':
+        return bool(re.match(ast[2], ast_sym(ast[1], env)))
+    elif ast[0] == 'dt_compat_enabled':
+        compat = ast[1][0]
+        for node in edt.nodes:
+            if compat in node.compats and node.status == 'okay':
+                return True
+        return False
+    elif ast[0] == 'dt_alias_exists':
+        alias = ast[1][0]
+        for node in edt.nodes:
+            if alias in node.aliases and node.status == 'okay':
+                return True
+        return False
+    elif ast[0] == 'dt_enabled_alias_with_parent_compat':
+        # Checks if the DT has an enabled alias node whose parent has
+        # a given compatible. For matching things like gpio-leds child
+        # nodes, which do not have compatibles themselves.
+        #
+        # The legacy "dt_compat_enabled_with_alias" form is still
+        # accepted but is now deprecated and causes a warning. This is
+        # meant to give downstream users some time to notice and
+        # adjust. Its argument order only made sense under the (bad)
+        # assumption that the gpio-leds child node has the same compatible
+
+        alias = ast[1][0]
+        compat = ast[1][1]
+
+        return ast_handle_dt_enabled_alias_with_parent_compat(edt, alias,
+                                                              compat)
+    elif ast[0] == 'dt_compat_enabled_with_alias':
+        compat = ast[1][0]
+        alias = ast[1][1]
+
+        _logger.warning('dt_compat_enabled_with_alias("%s", "%s"): '
+                        'this is deprecated, use '
+                        'dt_enabled_alias_with_parent_compat("%s", "%s") '
+                        'instead',
+                        compat, alias, alias, compat)
+
+        return ast_handle_dt_enabled_alias_with_parent_compat(edt, alias,
+                                                              compat)
+    elif ast[0] == 'dt_label_with_parent_compat_enabled':
+        compat = ast[1][1]
+        label = ast[1][0]
+        node = edt.label2node.get(label)
+        if node is not None:
+            parent = node.parent
+        else:
+            return False
+        return parent is not None and parent.status == 'okay' and parent.matching_compat == compat
+    elif ast[0] == 'dt_chosen_enabled':
+        chosen = ast[1][0]
+        node = edt.chosen_node(chosen)
+        if node and node.status == 'okay':
+            return True
+        return False
+    elif ast[0] == 'dt_nodelabel_enabled':
+        label = ast[1][0]
+        node = edt.label2node.get(label)
+        if node and node.status == 'okay':
+            return True
+        return False
+
+def ast_handle_dt_enabled_alias_with_parent_compat(edt, alias, compat):
+    # Helper shared with the now deprecated
+    # dt_compat_enabled_with_alias version.
+
+    for node in edt.nodes:
+        parent = node.parent
+        if parent is None:
+            continue
+        if (node.status == 'okay' and alias in node.aliases and
+                    parent.matching_compat == compat):
+            return True
+
+    return False
+
+mutex = threading.Lock()
+
+def parse(expr_text, env, edt):
+    """Given a text representation of an expression in our language,
+    use the provided environment to determine whether the expression
+    is true or false"""
+
+    # Like it's C counterpart, state machine is not thread-safe
+    mutex.acquire()
+    try:
+        ast = parser.parse(expr_text)
+    finally:
+        mutex.release()
+
+    return ast_expr(ast, env, edt)
+
+# Just some test code
+if __name__ == '__main__':
+
+    local_env = {
+        'A' : '1',
+        'C' : 'foo',
+        'D' : '20',
+        'E' : 0x100,
+        'F' : 'baz'
+    }
+
+
+    for line in open(sys.argv[1]).readlines():
+        lex.input(line)
+        for tok in iter(lex.token, None):  # type: ignore
+            print(tok.type, tok.value)
+
+        parser = yacc.yacc()
+        print(parser.parse(line))
+
+        print(parse(line, local_env, None))

--- a/src/twister2/kconfig_dts_filter/kconfig_dts_filter.py
+++ b/src/twister2/kconfig_dts_filter/kconfig_dts_filter.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+import os
+import pickle
+import re
+import sys
+from pathlib import Path
+
+from twister2.kconfig_dts_filter import expr_parser
+from twister2.kconfig_dts_filter.cmakecache import CMakeCache
+
+logger = logging.getLogger(__name__)
+
+
+class KconfigDtsFilter:
+    config_re = re.compile('(CONFIG_[A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
+    dt_re = re.compile('([A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
+
+    def __init__(self, zephyr_base: str | Path, build_dir: str | Path, platform_arch: str, platform_name: str,
+                 filter_exp: str) -> None:
+        self.build_dir: str = str(build_dir)
+        self.platform_arch: str = platform_arch
+        self.platform_name: str = platform_name
+        self.filter_exp: str = filter_exp
+
+        self.sysbuild: bool = False
+
+        # This is needed to load edt.pickle files by pickle.load().
+        sys.path.insert(0, os.path.join(zephyr_base, 'scripts', 'dts',
+                                        'python-devicetree', 'src'))
+        from devicetree import edtlib  # noqa: F401
+
+    def filter(self) -> bool:
+
+        # # TODO: add handling for unit_testing
+        # if self.platform.name == "unit_testing":
+        #     return {}
+
+        # # TODO: add handling for sysbuild
+        # if self.testsuite.sysbuild:
+        #     # Load domain yaml to get default domain build directory
+        #     domain_path = os.path.join(self.build_dir, "domains.yaml")
+        #     domains = Domains.from_file(domain_path)
+        #     logger.debug("Loaded sysbuild domain data from %s" % (domain_path))
+        #     domain_build = domains.get_default_domain().build_dir
+        #     cmake_cache_path = os.path.join(domain_build, "CMakeCache.txt")
+        #     defconfig_path = os.path.join(domain_build, "zephyr", ".config")
+        #     edt_pickle = os.path.join(domain_build, "zephyr", "edt.pickle")
+        # else:
+        cmake_cache_path = os.path.join(self.build_dir, 'CMakeCache.txt')
+        defconfig_path = os.path.join(self.build_dir, 'zephyr', '.config')
+        edt_pickle = os.path.join(self.build_dir, 'zephyr', 'edt.pickle')
+
+        defconfig = {}
+        with open(defconfig_path, 'r') as fp:
+            for line in fp.readlines():
+                m = self.config_re.match(line)
+                if not m:
+                    if line.strip() and not line.startswith('#'):
+                        sys.stderr.write('Unrecognized line %s\n' % line)
+                    continue
+                defconfig[m.group(1)] = m.group(2).strip()
+
+        cmake_conf = {}
+        try:
+            cache = CMakeCache.from_file(cmake_cache_path)
+        except FileNotFoundError:
+            cache = {}
+
+        for k in iter(cache):
+            cmake_conf[k.name] = k.value
+
+        filter_data = {
+            'ARCH': self.platform_arch,
+            'PLATFORM': self.platform_name
+        }
+        filter_data.update(os.environ)
+        filter_data.update(defconfig)
+        filter_data.update(cmake_conf)
+
+        # # TODO: add handling for sysbuild
+        # if self.testsuite.sysbuild and self.env.options.device_testing:
+        #     # Verify that twister's arguments support sysbuild.
+        #     # Twister sysbuild flashing currently only works with west, so
+        #     # --west-flash must be passed. Additionally, erasing the DUT
+        #     # before each test with --west-flash=--erase will inherently not
+        #     # work with sysbuild.
+        #     if self.env.options.west_flash is None:
+        #         logger.warning("Sysbuild test will be skipped. " +
+        #             "West must be used for flashing.")
+        #         return {os.path.join(self.platform.name, self.testsuite.name): True}
+        #     elif "--erase" in self.env.options.west_flash:
+        #         logger.warning("Sysbuild test will be skipped, " +
+        #             "--erase is not supported with --west-flash")
+        #         return {os.path.join(self.platform.name, self.testsuite.name): True}
+
+        try:
+            if os.path.exists(edt_pickle):
+                with open(edt_pickle, 'rb') as f:
+                    edt = pickle.load(f)
+            else:
+                edt = None
+            result = expr_parser.parse(self.filter_exp, filter_data, edt)
+
+        except (ValueError, SyntaxError) as se:
+            sys.stderr.write(
+                f'Failed processing kconfig and dts for {self.build_dir}\n')
+            raise se
+
+        return result

--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -133,7 +133,7 @@ def pytest_addoption(parser: pytest.Parser):
         dest='builder',
         action='store',
         default='west',
-        choices=('west',),
+        choices=('west', 'cmake'),
         help='Select builder type (default=%(default)s)'
     )
     twister_group.addoption(

--- a/src/twister2/specification_processor.py
+++ b/src/twister2/specification_processor.py
@@ -194,7 +194,6 @@ def should_be_skip(test_spec: YamlTestSpecification, platform: PlatformSpecifica
         should_skip_for_pytest_harness(test_spec, platform),
         should_skip_for_tag(test_spec, platform),
         should_skip_for_toolchain(test_spec, platform),
-        should_skip_for_filter_option(test_spec, platform),
     ]):
         return True
     return False
@@ -278,18 +277,6 @@ def should_skip_for_depends_on(test_spec: YamlTestSpecification, platform: Platf
     if not_supported_dependencies:
         reason = f'"{_join_strings(not_supported_dependencies)}" not occur in the "supported" section in the ' \
                  'platform definition yaml'
-        _log_test_skip(test_spec, platform, reason)
-        return True
-    return False
-
-
-def should_skip_for_filter_option(test_spec: YamlTestSpecification, platform: PlatformSpecification) -> bool:
-    """
-    TODO: This function should be removed when Kconfig and DTS filtering will be implemented correctly:
-    https://github.com/zephyrproject-rtos/twister/issues/14
-    """
-    if test_spec.filter != '':
-        reason = 'Kconfig and DTS filtering from yaml "filter option" is not implemented yet'
         _log_test_skip(test_spec, platform, reason)
         return True
     return False

--- a/tests/builder/cmake_builder_test.py
+++ b/tests/builder/cmake_builder_test.py
@@ -1,0 +1,109 @@
+import subprocess
+from unittest import mock
+
+import pytest
+
+from twister2.exceptions import TwisterBuildException
+
+
+@pytest.fixture
+def patched_cmake():
+    with mock.patch('twister2.builder.cmake_builder.CmakeBuilder._get_cmake', return_value='cmake') as cmake:
+        yield cmake
+
+
+@mock.patch('twister2.builder.cmake_builder.CmakeBuilder.run_cmake', return_value=None)
+@mock.patch('twister2.builder.cmake_builder.CmakeBuilder.run_build_generator', return_value=None)
+def test_if_run_build_generator_is_not_called_when_cmake_helper_is_selected(
+        run_build_generator, run_cmake, cmake_builder
+):
+    cmake_builder.build(cmake_helper=True)
+    run_cmake.assert_called_once_with(True)
+    run_build_generator.assert_not_called()
+
+
+@mock.patch('twister2.builder.cmake_builder.CmakeBuilder.run_cmake', return_value=None)
+@mock.patch('twister2.builder.cmake_builder.CmakeBuilder.run_build_generator', return_value=None)
+def test_if_run_build_generator_is_called_when_cmake_helper_is_not_selected(
+        run_build_generator, run_cmake, cmake_builder
+):
+    cmake_builder.build(cmake_helper=False)
+    run_cmake.assert_called_once_with(False)
+    run_build_generator.assert_called_once()
+
+
+@mock.patch('twister2.builder.cmake_builder.CmakeBuilder._run_command_in_subprocess', return_value=None)
+def test_if_run_cmake_calls_run_command_in_subprocess_with_proper_arguments(
+        patched_run_command_in_subprocess, patched_cmake, cmake_builder, build_config
+):
+    expected_command = [
+        'cmake', f'-S{build_config.source_dir}', f'-B{build_config.build_dir}',
+        f'-DBOARD={build_config.platform_name}', '-DEXTRA_CFLAGS=-Werror',
+        '-DEXTRA_AFLAGS=-Werror -Wa,--fatal-warnings', '-DEXTRA_LDFLAGS=-Wl,--fatal-warnings',
+        '-DEXTRA_GEN_DEFINES_ARGS=--edtlib-Werror', '-DCONF_FILE=prj_single.conf',
+    ]
+
+    cmake_builder.run_cmake(cmake_helper=False)
+    patched_run_command_in_subprocess.assert_called_once_with(expected_command, action='Cmake')
+
+
+@mock.patch('twister2.builder.cmake_builder.CmakeBuilder._run_command_in_subprocess', return_value=None)
+def test_if_run_cmake_calls_run_command_in_subprocess_with_proper_arguments_for_cmake_helper_flag_set(
+        patched_run_command_in_subprocess, patched_cmake, cmake_builder, build_config
+):
+    expected_command = [
+        'cmake', f'-S{build_config.source_dir}', f'-B{build_config.build_dir}',
+        f'-DBOARD={build_config.platform_name}', '-DEXTRA_CFLAGS=-Werror',
+        '-DEXTRA_AFLAGS=-Werror -Wa,--fatal-warnings', '-DEXTRA_LDFLAGS=-Wl,--fatal-warnings',
+        '-DEXTRA_GEN_DEFINES_ARGS=--edtlib-Werror', '-DCONF_FILE=prj_single.conf',
+        '-DMODULES=dts,kconfig', '-Pzephyr/cmake/package_helper.cmake'
+    ]
+
+    cmake_builder.run_cmake(cmake_helper=True)
+    patched_run_command_in_subprocess.assert_called_once_with(expected_command, action='Cmake')
+
+
+@mock.patch('twister2.builder.cmake_builder.CmakeBuilder._run_command_in_subprocess', return_value=None)
+def test_if_run_build_generator_calls_run_command_with_proper_arguments(
+        patched_run_command_in_subprocess, patched_cmake, cmake_builder, build_config
+):
+    expected_command = ['cmake', '--build', build_config.build_dir]
+
+    cmake_builder.run_build_generator()
+    patched_run_command_in_subprocess.assert_called_once_with(expected_command, action='building')
+
+
+@mock.patch('shutil.which', return_value='cmake')
+def test_if_get_cmake_returns_path_to_installed_cmake(patched_which, cmake_builder):
+    assert cmake_builder._get_cmake() == 'cmake'
+
+
+@mock.patch('shutil.which', return_value=None)
+def test_if_get_cmake_raises_exception_when_cmake_is_not_installed(patched_which, cmake_builder):
+    with pytest.raises(TwisterBuildException, match='cmake not found'):
+        cmake_builder._get_cmake()
+
+
+@mock.patch('subprocess.run', side_effect=subprocess.CalledProcessError(1, 'error message'))
+def test_if_run_command_in_subprocess_handles_subprocess_process_error(patched_run, cmake_builder):
+    with pytest.raises(TwisterBuildException, match='CMake error'):
+        cmake_builder._run_command_in_subprocess(['dummie'], 'building')
+
+
+@mock.patch('subprocess.run')
+def test_if_run_command_in_subprocess_handles_subprocess_return_code_zero_without_errors(
+        patched_run, cmake_builder
+):
+    patched_run.return_value = mock.MagicMock(returncode=0)
+    cmake_builder._run_command_in_subprocess(['dummie'], 'building')
+
+
+@mock.patch('subprocess.run')
+def test_if_run_command_in_subprocess_handles_subprocess_non_zero_return_code(patched_run, cmake_builder):
+    patched_run.return_value = mock.MagicMock(returncode=1)
+    msg = (
+        f'Failed running CMake {cmake_builder.build_config.source_dir} '
+        f'for platform: {cmake_builder.build_config.platform_name}'
+    )
+    with pytest.raises(TwisterBuildException, match=msg):
+        cmake_builder._run_command_in_subprocess(['dummie'], 'building')

--- a/tests/builder/conftest.py
+++ b/tests/builder/conftest.py
@@ -1,15 +1,33 @@
 import pytest
 
 from twister2.builder.builder_abstract import BuildConfig
+from twister2.builder.cmake_builder import CmakeBuilder
+from twister2.builder.west_builder import WestBuilder
 
 
-@pytest.fixture(name='build_config')
-def fixture_build_config() -> BuildConfig:
+@pytest.fixture
+def build_config(tmp_path) -> BuildConfig:
+    """Return BuildConfig"""
     return BuildConfig(
         zephyr_base='zephyr',
         source_dir='source',
         build_dir='build',
-        platform='native_posix',
+        output_dir=tmp_path,
+        platform_name='native_posix',
+        platform_arch='',  # TODO:
         scenario='bt',
+        kconfig_dts_filter='',
         extra_args_spec=['CONF_FILE=prj_single.conf']
     )
+
+
+@pytest.fixture
+def west_builder(build_config) -> WestBuilder:
+    """Return WestBuilder"""
+    return WestBuilder(build_config)
+
+
+@pytest.fixture
+def cmake_builder(build_config) -> CmakeBuilder:
+    """Return CmakeBuilder"""
+    return CmakeBuilder(build_config)

--- a/tests/builder/factory_test.py
+++ b/tests/builder/factory_test.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from twister2.builder.factory import BuilderFactory
+
+
+def test_if_get_builder_method_raises_KeyError_exception_when_there_is_no_register_builder():
+    with pytest.raises(KeyError):
+        BuilderFactory.get_builder('do_not_exist')
+
+
+def test_if_create_instance_method_can_create_new_class_instance():
+    class MyClass:
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+
+    BuilderFactory.register_builder_class('my_class', MyClass)  # type: ignore
+    my_class = BuilderFactory.create_instance('my_class', 1, b=2)
+    assert my_class.a == 1  # type: ignore
+    assert my_class.b == 2  # type: ignore

--- a/tests/builder/west_builder_test.py
+++ b/tests/builder/west_builder_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 from unittest import mock
 
@@ -7,22 +9,23 @@ from twister2.builder.builder_abstract import BuildConfig
 from twister2.builder.west_builder import WestBuilder
 from twister2.exceptions import TwisterBuildException, TwisterMemoryOverflowException
 
-
-@pytest.fixture(name='west_builder')
-def fixture_west_builder() -> WestBuilder:
-    """Return west builder"""
-    return WestBuilder()
+DEFAULT_CMAKE_ARGS: list[str] = [
+    '-DEXTRA_CFLAGS=-Werror',
+    '-DEXTRA_AFLAGS=-Werror -Wa,--fatal-warnings',
+    '-DEXTRA_LDFLAGS=-Wl,--fatal-warnings',
+    '-DEXTRA_GEN_DEFINES_ARGS=--edtlib-Werror'
+]
 
 
 def test_prepare_cmake_args_with_no_extra_args(west_builder: WestBuilder, build_config: BuildConfig):
     build_config.extra_configs = []
     build_config.extra_args_spec = []
     build_config.extra_args_cli = []
-    assert west_builder._prepare_cmake_args(build_config) == []
+    assert west_builder._prepare_cmake_args(build_config) == DEFAULT_CMAKE_ARGS
 
 
 def test_prepare_cmake_args_with_one_extra_arg(west_builder: WestBuilder, build_config: BuildConfig):
-    assert west_builder._prepare_cmake_args(build_config) == ['-DCONF_FILE=prj_single.conf']
+    assert west_builder._prepare_cmake_args(build_config) == DEFAULT_CMAKE_ARGS + ['-DCONF_FILE=prj_single.conf']
 
 
 def test_prepare_cmake_args_with_several_extra_args(west_builder: WestBuilder, build_config: BuildConfig):
@@ -30,7 +33,7 @@ def test_prepare_cmake_args_with_several_extra_args(west_builder: WestBuilder, b
     build_config.extra_args_spec = ['CONF_FILE=prj_single.conf']
     build_config.extra_args_cli = ['CONFIG_BOOT_DELAY=600']
     prepared_cmake_args = ['-DCONFIG_BOOT_BANNER=n', '-DCONF_FILE=prj_single.conf', '-DCONFIG_BOOT_DELAY=600']
-    assert west_builder._prepare_cmake_args(build_config) == prepared_cmake_args
+    assert west_builder._prepare_cmake_args(build_config) == DEFAULT_CMAKE_ARGS + prepared_cmake_args
 
 
 @mock.patch('shutil.which', return_value='west')
@@ -41,10 +44,11 @@ def test_if_west_builder_builds_code_from_source_without_errors(
     mocked_process = mock.MagicMock()
     mocked_process.returncode = 0
     patched_run.return_value = mocked_process
-    west_builder.build(build_config)
+    west_builder.build()
     patched_run.assert_called_with(
-        ['west', 'build', 'source', '--pristine', 'always', '--board', 'native_posix',
-         '--build-dir', 'build', '--', '-DCONF_FILE=prj_single.conf'],
+        ['west', build_config.build_dir, build_config.source_dir, '--pristine', 'always',
+         '--board', build_config.platform_name, '--build-dir', build_config.build_dir,
+         '--'] + DEFAULT_CMAKE_ARGS + ['-DCONF_FILE=prj_single.conf'],
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT
     )
 
@@ -52,31 +56,31 @@ def test_if_west_builder_builds_code_from_source_without_errors(
 @mock.patch('shutil.which', return_value='west')
 @mock.patch('subprocess.run')
 def test_if_west_builder_raises_exception_when_subprocess_returned_not_zero_returncode(
-        patched_run, patched_which, west_builder: WestBuilder, build_config: BuildConfig
+        patched_run, patched_which, west_builder: WestBuilder
 ):
     mocked_process = mock.MagicMock()
     mocked_process.returncode = 1
     mocked_process.stdout = 'fake build output'.encode()
     patched_run.return_value = mocked_process
     with pytest.raises(TwisterBuildException, match='Failed building source for platform: native_posix'):
-        west_builder.build(build_config)
+        west_builder.build()
 
 
 @mock.patch('shutil.which', return_value='west')
 @mock.patch('subprocess.run', side_effect=subprocess.CalledProcessError(1, 'test'))
 def test_if_west_builder_raises_exception_when_subprocess_raised_exception(
-        patched_run, patched_which, west_builder: WestBuilder, build_config: BuildConfig
+        patched_run, patched_which, west_builder: WestBuilder
 ):
     with pytest.raises(TwisterBuildException, match='Building error'):
-        west_builder.build(build_config)
+        west_builder.build()
 
 
 @mock.patch('shutil.which', return_value=None)
 def test_it_west_builder_raises_exception_when_west_was_not_found(
-        patched_which, west_builder: WestBuilder, build_config: BuildConfig
+        patched_which, west_builder: WestBuilder
 ):
     with pytest.raises(TwisterBuildException, match='west not found'):
-        west_builder.build(build_config)
+        west_builder.build()
 
 
 def test_if_overflow_exception_is_raised_when_memory_overflow_occurs(

--- a/tests/data/tests/common/testcase.yaml
+++ b/tests/data/tests/common/testcase.yaml
@@ -2,12 +2,14 @@ common:
   tags: kernel posix
   extra_configs:
       - CONFIG_POSIX_API=y
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
   min_ram: 32
 tests:
   xyz.common_merge_1:
     tags: picolibc
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
+    filter: CONFIG_PICOLIBC_SUPPORTED
     min_ram: 64
   xyz.common_merge_2:
     tags: arm

--- a/tests/yaml_file_test.py
+++ b/tests/yaml_file_test.py
@@ -7,8 +7,10 @@ def test_if_can_read_test_specifications_from_yaml_common(twister_config, resour
         if spec.original_name == 'xyz.common_merge_1':
             assert spec.tags == {'kernel', 'posix', 'picolibc'}
             assert spec.extra_configs == ['CONFIG_NEWLIB_LIBC=y', 'CONFIG_POSIX_API=y']
+            assert spec.filter == '(CONFIG_PICOLIBC_SUPPORTED) and (TOOLCHAIN_HAS_NEWLIB == 1)'
             assert spec.min_ram == 64
         elif spec.original_name == 'xyz.common_merge_2':
             assert spec.tags == {'kernel', 'posix', 'arm'}
             assert spec.extra_configs == ['CONFIG_POSIX_API=y']
+            assert spec.filter == 'TOOLCHAIN_HAS_NEWLIB == 1'
             assert spec.min_ram == 32


### PR DESCRIPTION
PR with adding Kconfig and DTS filtration. Files collected in `src/twister2/kconfig_dts_filter` were copied 1:1 from Twister v1.
 
Can be tested by:
```
pytest -vv -s --log-level=INFO -o log_cli=true --clear=archive --results-json=twister-out/results.json --platform=mps2_an385 samples/userspace/hello_world_user tests/drivers/sensor/sbs_gauge samples/arch/smp/pi 
```

 Only one test should be passed:
`samples/userspace/hello_world_user/sample.yaml::sample.helloworld[mps2_an385]`
And two next should be skipped:
`tests/drivers/sensor/sbs_gauge/testcase.yaml::drivers.sbs_gauge[mps2_an385]`
`samples/arch/smp/pi/sample.yaml::sample.smp.pi[mps2_an385]`
 
This PR introduces also possibility to build application directly by CMake
 
Fixes: #14