### PR TITLE
Detect memory overflow

### DIFF
--- a/src/twister2/builder/builder_abstract.py
+++ b/src/twister2/builder/builder_abstract.py
@@ -18,6 +18,7 @@ class BuildConfig:
     extra_configs: list[str] = field(default_factory=list)
     extra_args_spec: list[str] = field(default_factory=list)
     extra_args_cli: list[str] = field(default_factory=list)
+    overflow_as_errors: bool = field(default_factory=bool)
 
 
 class BuilderAbstract(abc.ABC):

--- a/src/twister2/builder/west_builder.py
+++ b/src/twister2/builder/west_builder.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 import subprocess
 
 from twister2.builder.builder_abstract import BuildConfig, BuilderAbstract
-from twister2.exceptions import TwisterBuildException
+from twister2.exceptions import TwisterBuildException, TwisterMemoryOverflowException
 from twister2.helper import log_command
 
 logger = logging.getLogger(__name__)
@@ -51,10 +52,7 @@ class WestBuilder(BuilderAbstract):
                 self._log_output(process.stdout, logging.DEBUG)
                 logger.info('Finished building %s for %s', build_config.source_dir, build_config.platform)
             else:
-                self._log_output(process.stdout, logging.INFO)
-                msg = f'Failed building {build_config.source_dir} for platform: {build_config.platform}'
-                logger.error(msg)
-                raise TwisterBuildException(msg)
+                self._handle_build_failure(build_config, process.stdout)
 
     def _prepare_cmake_args(self, build_config: BuildConfig) -> list[str]:
         """
@@ -79,6 +77,29 @@ class WestBuilder(BuilderAbstract):
     @staticmethod
     def _prepare_extra_configs(args: list[str]) -> list[str]:
         return ['-D{}'.format(arg) for arg in args]
+
+    def _handle_build_failure(self, build_config: BuildConfig, stdout_output: bytes):
+        self._log_output(stdout_output, logging.INFO)
+        self._check_memory_overflow(build_config, stdout_output)
+        msg = f'Failed building {build_config.source_dir} for platform: {build_config.platform}'
+        logger.error(msg)
+        raise TwisterBuildException(msg)
+
+    @staticmethod
+    def _check_memory_overflow(build_config: BuildConfig, output: bytes) -> None:
+        build_output = output.decode()
+        memory_overflow_pattern = 'region `(FLASH|ROM|RAM|ICCM|DCCM|SRAM|dram0_1_seg)\' overflowed by'
+        imgtool_overflow_pattern = r'Error: Image size \(.*\) \+ trailer \(.*\) exceeds requested size'
+        memory_overflow_found = re.findall(memory_overflow_pattern, build_output)
+        if memory_overflow_found:
+            msg = f'Memory overflow during building {build_config.source_dir} for platform: ' \
+                  f'{build_config.platform}'
+            raise TwisterMemoryOverflowException(msg)
+        imgtool_overflow_found = re.findall(imgtool_overflow_pattern, build_output)
+        if imgtool_overflow_found:
+            msg = f'Imgtool memory overflow during building {build_config.source_dir} for platform: ' \
+                  f'{build_config.platform}'
+            raise TwisterMemoryOverflowException(msg)
 
     @staticmethod
     def _log_output(output: bytes, level: int) -> None:

--- a/src/twister2/exceptions.py
+++ b/src/twister2/exceptions.py
@@ -22,6 +22,14 @@ class TwisterBuildException(TwisterException):
     """Any exception during building."""
 
 
+class TwisterBuildSkipException(TwisterException):
+    """Raised when test was skipped during building"""
+
+
+class TwisterMemoryOverflowException(TwisterException):
+    """Raised when memory overflow appeared during building."""
+
+
 class TwisterFlashException(TwisterException):
     """Any exception during flashing."""
 

--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -155,6 +155,12 @@ def pytest_addoption(parser: pytest.Parser):
              'will be translated to '
              'cmake -DUSE_CCACHE=0'
     )
+    twister_group.addoption(
+        '--overflow-as-errors',
+        default=False,
+        action='store_true',
+        help='Treat memory overflows as errors.'
+    )
 
 
 def pytest_configure(config: pytest.Config):

--- a/src/twister2/twister_config.py
+++ b/src/twister2/twister_config.py
@@ -26,6 +26,7 @@ class TwisterConfig:
     device_testing: bool = False
     fixtures: list[str] = field(default_factory=list, repr=False)
     extra_args_cli: list = field(default_factory=list)
+    overflow_as_errors: bool = False
 
     @classmethod
     def create(cls, config: pytest.Config) -> TwisterConfig:
@@ -44,6 +45,7 @@ class TwisterConfig:
         device_testing: bool = config.option.device_testing
         fixtures: list[str] = config.option.fixtures
         extra_args_cli: list[str] = config.getoption('--extra-args')
+        overflow_as_errors: bool = config.option.overflow_as_errors
 
         hardware_map_list: list[HardwareMap] = []
         if hardware_map_file:
@@ -68,6 +70,7 @@ class TwisterConfig:
             device_testing=device_testing,
             fixtures=fixtures,
             extra_args_cli=extra_args_cli,
+            overflow_as_errors=overflow_as_errors
         )
         return cls(**data)
 

--- a/tests/twister2_plugin_test.py
+++ b/tests/twister2_plugin_test.py
@@ -18,6 +18,7 @@ def test_twister_help(pytester):
         '*Clear twister artifacts*',
         '*--extra-args=EXTRA_ARGS*',
         '*Extra CMake arguments*',
+        '*--overflow-as-errors*'
     ])
 
 


### PR DESCRIPTION
By default if during building  memory overflow is detected, then this test should be skipped. If user uses `--overflow-as-errors` then test with overflow should be marked as failed (error).

Can be tested by:

Test should be skipped:
```
pytest -vv -s --log-level=INFO -o log_cli=true --clear=archive --platform=qemu_cortex_m3 --results-json=twister-out/results.json tests/lib/cmsis_dsp/matrix -k libraries.cmsis_dsp.matrix.unary_f64.fpu
```

Test should be marked as failed (error):
```
pytest -vv -s --log-level=INFO -o log_cli=true --clear=archive --platform=qemu_cortex_m3 --results-json=twister-out/results.json tests/lib/cmsis_dsp/matrix -k libraries.cmsis_dsp.matrix.unary_f64.fpu --overflow-as-errors
```

Fixes: #10 