### PR TITLE
Set archive as default option for clear option

### DIFF
--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -120,7 +120,7 @@ def pytest_addoption(parser: pytest.Parser):
         '--clear',
         dest='clear',
         action='store',
-        default='no',
+        default='archive',
         choices=('no', 'delete', 'archive'),
         help='Clear twister artifacts. '
              '"no" - use previous artifacts, '


### PR DESCRIPTION
To have similar workflow to Twister v1 the default option for "--clear" option has to be set as "archive". Thanks to this each time when twister is called new `twister-out` folder is created and previous one (if exists) is renamed.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>