### PR TITLE
Align selected platform - first part, without updating platform scope per testsuite

### DIFF
--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -54,7 +54,8 @@ def pytest_addoption(parser: pytest.Parser):
     twister_group.addoption(
         '--all',
         action='store_true',
-        help='Build/test on all platforms. Any --platform arguments ignored'
+        help='Build/test on all platforms. Any --platform arguments '
+             'will be ignored'
     )
     twister_group.addoption(
         '--board-root',

--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -101,11 +101,6 @@ def pytest_addoption(parser: pytest.Parser):
         help='load hardware map from a file',
     )
     twister_group.addoption(
-        '-G', '--integration',
-        action='store_true',
-        help='Run integration tests',
-    )
-    twister_group.addoption(
         '--emulation-only',
         action='store_true',
         help='Only build and run emulation platforms',

--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -52,6 +52,11 @@ def pytest_addoption(parser: pytest.Parser):
         help='build tests for specific platforms'
     )
     twister_group.addoption(
+        '--all',
+        action='store_true',
+        help='Build/test on all platforms. Any --platform arguments ignored'
+    )
+    twister_group.addoption(
         '--board-root',
         metavar='PATH',
         action='append',
@@ -94,6 +99,21 @@ def pytest_addoption(parser: pytest.Parser):
         '--hardware-map',
         metavar='PATH',
         help='load hardware map from a file',
+    )
+    twister_group.addoption(
+        '-G', '--integration',
+        action='store_true',
+        help='Run integration tests',
+    )
+    twister_group.addoption(
+        '--emulation-only',
+        action='store_true',
+        help='Only build and run emulation platforms',
+    )
+    twister_group.addoption(
+        '--arch',
+        action='append',
+        help='Arch filter for testing'
     )
     twister_group.addoption(
         '--tags',

--- a/src/twister2/twister_config.py
+++ b/src/twister2/twister_config.py
@@ -48,7 +48,6 @@ class TwisterConfig:
         fixtures: list[str] = config.option.fixtures
         extra_args_cli: list[str] = config.getoption('--extra-args')
         overflow_as_errors: bool = config.option.overflow_as_errors
-        integration_mode: bool = config.option.integration
         emulation_only: bool = config.option.emulation_only
         architectures: list[str] = config.option.arch
 
@@ -93,7 +92,6 @@ class TwisterConfig:
             fixtures=fixtures,
             extra_args_cli=extra_args_cli,
             overflow_as_errors=overflow_as_errors,
-            integration_mode=integration_mode,
             emulation_only=emulation_only,
             architectures=architectures
         )

--- a/tests/data/boards/nios2/altera_max10/altera_max10.yaml
+++ b/tests/data/boards/nios2/altera_max10/altera_max10.yaml
@@ -1,0 +1,6 @@
+identifier: altera_max10
+name: Altera MAX10
+type: mcu
+arch: nios2
+toolchain:
+  - zephyr

--- a/tests/data/boards/posix/native_posix/native_posix.yaml
+++ b/tests/data/boards/posix/native_posix/native_posix.yaml
@@ -1,6 +1,7 @@
 identifier: native_posix
 name: Native 32-bit POSIX port
 type: native
+simulation: native
 arch: posix
 ram: 65536
 flash: 65536

--- a/tests/platfrom_specification_test.py
+++ b/tests/platfrom_specification_test.py
@@ -30,15 +30,19 @@ def test_if_platform_specification_can_be_load_from_yaml_file(resources):
 def test_if_discover_platforms_discovers_all_defined_platforms_in_directory(resources: Path):
     boards_dir = resources / 'boards'
     platforms = list(discover_platforms(boards_dir))
-    assert len(platforms) == 3
-    assert {platform.identifier for platform in platforms} == {'qemu_cortex_m3', 'mps2_an521_remote', 'native_posix'}
+    assert len(platforms) == 4
+    assert {platform.identifier for platform in platforms} == {
+        'qemu_cortex_m3', 'mps2_an521_remote', 'native_posix', 'altera_max10'
+    }
 
 
 def test_if_search_platforms_discovers_all_defined_platforms(resources: Path):
     zephyr_base = str(resources)
     platforms = search_platforms(zephyr_base=zephyr_base)
-    assert len(platforms) == 3
-    assert {platform.identifier for platform in platforms} == {'qemu_cortex_m3', 'mps2_an521_remote', 'native_posix'}
+    assert len(platforms) == 4
+    assert {platform.identifier for platform in platforms} == {
+        'qemu_cortex_m3', 'mps2_an521_remote', 'native_posix', 'altera_max10'
+    }
 
 
 def test_if_validate_platforms_list_raises_exception_for_duplicated_platform():

--- a/tests/twister2_plugin_platform_selection_test.py
+++ b/tests/twister2_plugin_platform_selection_test.py
@@ -1,0 +1,121 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ('extend_command, expected, not_expected'),
+    [
+        (
+            '--all',
+            ['*native_posix*', '*qemu_cortex_m3*', '*altera_max10*', '*mps2_an521_remote*'],
+            []
+        ),
+        (
+            '--emulation-only',
+            ['*native_posix*', '*qemu_cortex_m3*', '*mps2_an521_remote*'],
+            ['*altera_max10*']
+        ),
+        (
+            '--arch=arm',
+            ['*qemu_cortex_m3*', '*mps2_an521_remote*'],
+            ['*native_posix*', '*altera_max10*']
+        ),
+        (
+            '--arch=posix --arch=nios2',
+            ['*native_posix*', '*altera_max10*'],
+            ['*qemu_cortex_m3*', '*mps2_an521_remote*']
+        ),
+        (
+            '',
+            ['*native_posix*', '*mps2_an521_remote*'],
+            ['*qemu_cortex_m3*', '*altera_max10*']
+        )
+    ],
+    ids=[
+        'all-platforms',
+        'emulation-only',
+        'arch-arm',
+        'select-two-archs',
+        'default-platforms'
+    ]
+)
+def test_if_selected_proper_platforms(
+        pytester, resources, extend_command, expected, not_expected
+):
+    pytester.copy_example(str(resources))
+    test_dir: Path = pytester.path / 'tests' / 'hello_world'
+    runpytest_args = [
+        f'--zephyr-base={str(pytester.path)}',
+        '--collect-only',
+        str(test_dir)
+    ]
+    if extend_command:
+        runpytest_args.extend(extend_command.split(' '))
+    result = pytester.runpytest(*runpytest_args)
+
+    result.stdout.fnmatch_lines_random(expected)
+    for no_line in not_expected:
+        result.stdout.no_fnmatch_line(no_line)
+
+
+@pytest.mark.parametrize(
+    ('extend_command, expected, not_expected'),
+    [
+        (
+            '',
+            ['*altera_max10*'],
+            ['*native_posix*', '*qemu_cortex_m3*', '*mps2_an521_remote*']
+        ),
+        (
+            '--platform=native_posix',
+            ['*native_posix*'],
+            ['*altera_max10*', '*qemu_cortex_m3*', '*mps2_an521_remote*']
+        ),
+        (
+            '--all',
+            ['*native_posix*', '*qemu_cortex_m3*', '*altera_max10*', '*mps2_an521_remote*'],
+            []
+        )
+    ],
+    ids=[
+        'platform-from-hardware-map',
+        'platform-from-command',
+        'all-platforms'
+    ]
+)
+def test_if_selected_proper_platform_with_hardware_map(
+        pytester, resources, extend_command, expected, not_expected
+):
+    pytester.copy_example(str(resources))
+    hardware_map = pytester.path / 'hardware_map.yml'
+    hardware_map.write_text(textwrap.dedent("""\
+        - available: true
+          connected: true
+          id: 01234
+          platform: altera_max10
+          runner: jlink
+          serial: /dev/ttyACM0
+        - available: true
+          connected: true
+          id: 01234
+          platform: altera_max10
+          runner: jlink
+          serial: /dev/ttyACM1
+    """))
+    test_dir: Path = pytester.path / 'tests' / 'hello_world'
+    runpytest_args = [
+        f'--zephyr-base={str(pytester.path)}',
+        '--collect-only',
+        '--device-testing',
+        f'--hardware-map={hardware_map}',
+        str(test_dir)
+    ]
+    if extend_command:
+        runpytest_args.extend(extend_command.split(' '))
+    result = pytester.runpytest(*runpytest_args)
+
+    result.stdout.fnmatch_lines_random(expected)
+    for no_line in not_expected:
+        result.stdout.no_fnmatch_line(no_line)

--- a/tests/twister2_plugin_test.py
+++ b/tests/twister2_plugin_test.py
@@ -18,7 +18,10 @@ def test_twister_help(pytester):
         '*Clear twister artifacts*',
         '*--extra-args=EXTRA_ARGS*',
         '*Extra CMake arguments*',
-        '*--overflow-as-errors*'
+        '*--overflow-as-errors*',
+        '*--emulation-only*',
+        '*--arch=ARCH*',
+        '*--all*'
     ])
 
 


### PR DESCRIPTION
First part, without filtering platforms with info from testcase/sample yamls 
* added --all
```
pytest samples/hello_world -vv --clear=delete --collect-only --all
527 tests collected
```
* added --emulation-only
```
pytest samples/hello_world -vv --clear=delete --collect-only --emulation-only
60 tests collected
```
* added --arch ARCH
```
pytest samples/hello_world -vv --clear=delete --collect-only --arch arm
392 tests collected
pytest samples/hello_world -vv --clear=delete --collect-only --arch nios2 --arch posix
5 tests collected
```
* take platform from hardware_map if platform not given
```
pytest samples/hello_world -vv --clear=delete --collect-only --hardware-map=map.yml
<YamlFunction sample.basic.helloworld[nrf9160dk_nrf9160_ns]>
```

Commands from twister1 to compare (interrupt test after building is starting and check output in testplan.json or twister.xml)
```
scripts/twister -T samples/hello_world -c -vv --all
scripts/twister -T samples/hello_world -c -vv --emulation-only
scripts/twister -T samples/hello_world -c -vv --arch posix
scripts/twister -T samples/hello_world -c -vv --device-testing --hardware-map map.yml

grep 'platform' twister-out/testplan.json | wc -l
```
There are differences between results in twisterv2 and twisterv1, because till now updating platform scope with testsuite parameters (e.g. platform_allow) is not added.
