### PR TITLE
filtration: Skip unit type tests

### DIFF
--- a/src/twister2/specification_processor.py
+++ b/src/twister2/specification_processor.py
@@ -192,6 +192,7 @@ def should_be_skip(test_spec: YamlTestSpecification, platform: PlatformSpecifica
         should_skip_for_platform(test_spec, platform),
         should_skip_for_platform_type(test_spec, platform),
         should_skip_for_pytest_harness(test_spec, platform),
+        should_skip_for_spec_type_unit(test_spec, platform),
         should_skip_for_tag(test_spec, platform),
         should_skip_for_toolchain(test_spec, platform),
     ]):
@@ -265,6 +266,13 @@ def should_skip_for_min_flash(test_spec: YamlTestSpecification, platform: Platfo
 def should_skip_for_pytest_harness(test_spec: YamlTestSpecification, platform: PlatformSpecification) -> bool:
     if test_spec.harness == 'pytest':
         _log_test_skip(test_spec, platform, 'test harness "pytest" is natively supported by pytest')
+        return True
+    return False
+
+
+def should_skip_for_spec_type_unit(test_spec: YamlTestSpecification, platform: PlatformSpecification) -> bool:
+    if test_spec.type == 'unit':
+        _log_test_skip(test_spec, platform, 'Unit type tests are not for regular platforms')
         return True
     return False
 

--- a/tests/specification_processor_test.py
+++ b/tests/specification_processor_test.py
@@ -17,6 +17,7 @@ from twister2.specification_processor import (
     should_skip_for_platform,
     should_skip_for_platform_type,
     should_skip_for_pytest_harness,
+    should_skip_for_spec_type_unit,
     should_skip_for_tag,
     should_skip_for_toolchain,
 )
@@ -32,6 +33,16 @@ def testcase() -> YamlTestSpecification:
         platform='platform',
         source_dir=Path('dummy_path')
     )
+
+
+def test_should_skip_for_spec_type_unit_positive(testcase, platform):
+    testcase.type = "unit"
+    assert should_skip_for_spec_type_unit(testcase, platform)
+
+
+def test_should_skip_for_spec_type_unit_negative(testcase, platform):
+    testcase.type = ""
+    assert should_skip_for_spec_type_unit(testcase, platform) is False
 
 
 def test_should_skip_for_tag_for_only_tags_positive(testcase, platform):


### PR DESCRIPTION
Twister supports a special type of tests marked with type: unit. These tests require special handling as they are mocking unused modules. Those tests cannot be executed on a regular platforms. For now, such tests will be always skipped in v2.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>