### PR TITLE
specification_processor: fix depends_on filter

### DIFF
--- a/src/twister2/specification_processor.py
+++ b/src/twister2/specification_processor.py
@@ -278,9 +278,10 @@ def should_skip_for_spec_type_unit(test_spec: YamlTestSpecification, platform: P
 
 
 def should_skip_for_depends_on(test_spec: YamlTestSpecification, platform: PlatformSpecification) -> bool:
+    parsed_platform_supported = _parse_raw_platform_supported(platform.supported)
     not_supported_dependencies = []
     for dependency in test_spec.depends_on:
-        if dependency not in platform.supported:
+        if dependency not in parsed_platform_supported:
             not_supported_dependencies.append(dependency)
     if not_supported_dependencies:
         reason = f'"{_join_strings(not_supported_dependencies)}" not occur in the "supported" section in the ' \
@@ -288,6 +289,18 @@ def should_skip_for_depends_on(test_spec: YamlTestSpecification, platform: Platf
         _log_test_skip(test_spec, platform, reason)
         return True
     return False
+
+
+def _parse_raw_platform_supported(raw_supported: set) -> set:
+    """
+    Parse platform supported features and extract single features, for example:
+    {'netif:eth} -> {'netif', 'eth'}
+    """
+    supported = set()
+    for raw_feature in raw_supported:
+        for feature in raw_feature.split(':'):
+            supported.add(feature)
+    return supported
 
 
 def _join_filters(args: list[str]) -> str:

--- a/tests/specification_processor_test.py
+++ b/tests/specification_processor_test.py
@@ -36,12 +36,12 @@ def testcase() -> YamlTestSpecification:
 
 
 def test_should_skip_for_spec_type_unit_positive(testcase, platform):
-    testcase.type = "unit"
+    testcase.type = 'unit'
     assert should_skip_for_spec_type_unit(testcase, platform)
 
 
 def test_should_skip_for_spec_type_unit_negative(testcase, platform):
-    testcase.type = ""
+    testcase.type = ''
     assert should_skip_for_spec_type_unit(testcase, platform) is False
 
 
@@ -189,13 +189,13 @@ def test_should_skip_for_min_flash_positive(testcase, platform):
 
 def test_should_skip_for_depends_on_negative(testcase, platform):
     testcase.depends_on = {'spi'}
-    platform.supported = {'gpio'}
+    platform.supported = {'gpio', 'netif:eth'}
     assert should_skip_for_depends_on(testcase, platform)
 
 
 def test_should_skip_for_depends_on_positive(testcase, platform):
-    testcase.depends_on = {'spi'}
-    platform.supported = {'gpio', 'spi'}
+    testcase.depends_on = {'netif'}
+    platform.supported = {'gpio', 'netif:eth'}
     assert should_skip_for_depends_on(testcase, platform) is False
 
 


### PR DESCRIPTION
To be compatible with Twister v1 supported complex features collected in platform yaml definition should be split into single one. For example:
{'netif:eth'} -> {'netif', 'eth'}

Without this mechanism it is impossible to run for example this test:
```
pytest -vvs --log-level=INFO -o log_cli=true --platform=nrf52840dk_nrf52840 --results-json=twister-out/results.json tests/net/virtual/testcase.yaml::net.virtual.tunnel.ipip 
```

Fragment of corresponding logic in Twister v1:
https://github.com/zephyrproject-rtos/zephyr/blob/48a6f160f285785d61101446930689c57468b332/scripts/pylib/twister/twisterlib/platform.py#L64-L67