### PR TITLE
test specification: Add platform_key to allowed schema

### DIFF
--- a/src/twister2/yaml_test_specification.py
+++ b/src/twister2/yaml_test_specification.py
@@ -48,6 +48,7 @@ class YamlTestSpecification:
     ignore_qemu_crash: bool = False
     platform_allow: set[str] = field(default_factory=set)
     platform_exclude: set[str] = field(default_factory=set)
+    platform_key: list[str] = field(default_factory=list)
     platform_type: list[str] = field(default_factory=list)
     harness_config: dict = field(default_factory=dict)
     toolchain_exclude: set[str] = field(default_factory=set)
@@ -122,6 +123,7 @@ class TestSchema(Schema):
     modules = fields.List(fields.Str())
     platform_exclude = fields.Str()
     platform_allow = fields.Str()
+    platform_key = fields.List(fields.Str())
     platform_type = fields.List(fields.Str())
     tags = fields.Str()
     timeout = fields.Int()


### PR DESCRIPTION
Twister added platform_key keyword to test yamls.
https://github.com/zephyrproject-rtos/zephyr/pull/53110 This patch adopts the yaml schema so its validation won't failed on such tests.
The platform_key functionality is not yet added.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>