### PR TITLE
Added support for unit_testing board

### DIFF
--- a/src/twister2/device/factory.py
+++ b/src/twister2/device/factory.py
@@ -9,6 +9,7 @@ from twister2.device.qemu_adapter import QemuAdapter
 from twister2.device.simulator_adapter import (
     CustomSimulatorAdapter,
     NativeSimulatorAdapter,
+    UnitSimulatorAdapter,
 )
 from twister2.exceptions import TwisterRunException
 
@@ -39,5 +40,6 @@ class DeviceFactory:
 
 DeviceFactory.register_device_class('custom', CustomSimulatorAdapter)
 DeviceFactory.register_device_class('native', NativeSimulatorAdapter)
+DeviceFactory.register_device_class('unit', UnitSimulatorAdapter)
 DeviceFactory.register_device_class('hardware', HardwareAdapter)
 DeviceFactory.register_device_class('qemu', QemuAdapter)

--- a/src/twister2/device/simulator_adapter.py
+++ b/src/twister2/device/simulator_adapter.py
@@ -181,6 +181,19 @@ class NativeSimulatorAdapter(SimulatorAdapterBase):
         self.command = [str((Path(build_dir) / 'zephyr' / 'zephyr.exe').resolve())]
 
 
+class UnitSimulatorAdapter(SimulatorAdapterBase):
+    """Simulator adapter to run unit tests"""
+
+    def generate_command(self, build_dir: Path | str) -> None:
+        """
+        Return command to run.
+
+        :param build_dir: build directory
+        :return: command to run
+        """
+        self.command = [str((Path(build_dir) / 'testbinary').resolve())]
+
+
 class CustomSimulatorAdapter(SimulatorAdapterBase):
 
     def generate_command(self, build_dir: Path | str) -> None:

--- a/src/twister2/fixtures/common.py
+++ b/src/twister2/fixtures/common.py
@@ -84,5 +84,7 @@ class SetupTestManager:
             return 'qemu'
         elif self.platform.simulation != 'na':
             return 'custom'
+        elif self.platform.type == 'unit':
+            return 'unit'
         else:
             return ''

--- a/src/twister2/specification_processor.py
+++ b/src/twister2/specification_processor.py
@@ -271,8 +271,7 @@ def should_skip_for_pytest_harness(test_spec: YamlTestSpecification, platform: P
 
 
 def should_skip_for_spec_type_unit(test_spec: YamlTestSpecification, platform: PlatformSpecification) -> bool:
-    # TODO: Align unit type workflow with V1. Currently it is not supported in V2.
-    if test_spec.type == 'unit':
+    if (platform.type == 'unit') != (test_spec.type == 'unit'):
         _log_test_skip(test_spec, platform, 'Unit type tests cannot be executed on regular platforms')
         return True
     return False

--- a/tests/device/simulator_adapter_test.py
+++ b/tests/device/simulator_adapter_test.py
@@ -6,6 +6,7 @@ import pytest
 from twister2.device.simulator_adapter import (
     CustomSimulatorAdapter,
     NativeSimulatorAdapter,
+    UnitSimulatorAdapter,
 )
 from twister2.exceptions import TwisterRunException
 from twister2.twister_config import TwisterConfig
@@ -107,3 +108,10 @@ def test_if_custom_simulator_adapter_get_command_returns_empty_string(patched_wh
     device.generate_command('build_dir')
     assert isinstance(device.command, list)
     assert device.command == []
+
+
+def test_if_unit_simulator_adapter_get_command_returns_proper_string(resources) -> None:
+    device = UnitSimulatorAdapter(TwisterConfig(zephyr_base='zephyr'))
+    device.generate_command(resources)
+    assert isinstance(device.command, list)
+    assert device.command == [str(resources.joinpath('testbinary'))]

--- a/tests/fixtures/common_test.py
+++ b/tests/fixtures/common_test.py
@@ -34,6 +34,7 @@ def test_if_test_should_be_skipped(build_only, device_testing, runnable, platfor
         ('integration', 'native', 'native', 'native'),
         ('integration', 'sim', 'nsim', 'custom'),
         ('integration', 'mcu', 'na', 'hardware'),
+        ('integration', 'unit', 'na', 'unit'),
     ]
 )
 def test_if_get_device_type_returns_proper_device(


### PR DESCRIPTION
Work as `native_posix`, but instead of `zephyr.exe` uses `testbinary` executable.

Collect tests on Twister2:
```
pytest -vv --clear=delete --testplan-json=twister-out/testplan.json --platform=unit_testing tests --collect-only
191 tests collected in 1.62s
```
On twister1:
```
scripts/twister -T tests -p unit_testing -vv -c --dry-run
grep '"platform":' twister-out/testplan.json | wc -l
192 - one is mark as skipped
```

Run tests on unit_testing platform:
```
pytest -vv --clear=delete --testplan-json=twister-out/testplan.json --platform=unit_testing tests -n 4
191 passed, 264 skipped, 1981 subtests passed in 121.59s (0:02:01)
```

Fixes: #98