### PR TITLE
bugfix: filtering: Fix logic for tags defined in platform specification

### DIFF
--- a/src/twister2/platform_specification.py
+++ b/src/twister2/platform_specification.py
@@ -35,8 +35,6 @@ class PlatformSpecification:
     twister: bool = True
     ram: int = 128  # in kilobytes
     flash: int = 512  # in kilobytes
-    ignore_tags: list[str] = field(default_factory=list)
-    only_tags: list[str] = field(default_factory=list)
     default: bool = False
     supported: set = field(default_factory=set)
     arch: str = ''
@@ -96,8 +94,6 @@ class PlatformSchema(Schema):
     twister = fields.Bool()
     ram = fields.Int()
     flash = fields.Int()
-    ignore_tags = fields.List(fields.Str())
-    only_tags = fields.List(fields.Str())
     default = fields.Bool()
     supported = fields.List(fields.Str())
     arch = fields.Str()

--- a/src/twister2/specification_processor.py
+++ b/src/twister2/specification_processor.py
@@ -213,11 +213,11 @@ def should_skip_for_toolchain(test_spec: YamlTestSpecification, platform: Platfo
 
 
 def should_skip_for_tag(test_spec: YamlTestSpecification, platform: PlatformSpecification) -> bool:
-    if platform.only_tags and not set(platform.only_tags) & test_spec.tags:
-        _log_test_skip(test_spec, platform, 'testcase.tag not in platform.only_tags')
+    if platform.testing.only_tags and not set(platform.testing.only_tags) & test_spec.tags:
+        _log_test_skip(test_spec, platform, 'testcase.tag not in platform.testing.only_tags')
         return True
-    if platform.ignore_tags and set(platform.ignore_tags) & test_spec.tags:
-        _log_test_skip(test_spec, platform, 'testcase.tag in platform.ignore_tags')
+    if platform.testing.ignore_tags and set(platform.testing.ignore_tags) & test_spec.tags:
+        _log_test_skip(test_spec, platform, 'testcase.tag in platform.testing.ignore_tags')
         return True
     return False
 

--- a/tests/specification_processor_test.py
+++ b/tests/specification_processor_test.py
@@ -47,25 +47,25 @@ def test_should_skip_for_spec_type_unit_negative(testcase, platform):
 
 def test_should_skip_for_tag_for_only_tags_positive(testcase, platform):
     testcase.tags = {'tag1', 'tag2'}
-    platform.only_tags = ['tag3', 'tag4']
+    platform.testing.only_tags = ['tag3', 'tag4']
     assert should_skip_for_tag(testcase, platform)
 
 
 def test_should_skip_for_tag_for_only_tags_negative(testcase, platform):
     testcase.tags = {'tag1', 'tag2'}
-    platform.only_tags = ['tag1', 'tag4']
+    platform.testing.only_tags = ['tag1', 'tag4']
     assert should_skip_for_tag(testcase, platform) is False
 
 
 def test_should_skip_for_tag_for_ignore_tags_positive(testcase, platform):
     testcase.tags = {'tag1', 'tag2'}
-    platform.ignore_tags = ['tag1', 'tag4']
+    platform.testing.ignore_tags = ['tag1', 'tag4']
     assert should_skip_for_tag(testcase, platform)
 
 
 def test_should_skip_for_tag_for_ignore_tags_negative(testcase, platform):
     testcase.tags = {'tag1', 'tag2'}
-    platform.ignore_tags = ['tag3', 'tag4']
+    platform.testing.ignore_tags = ['tag3', 'tag4']
     assert should_skip_for_tag(testcase, platform) is False
 
 

--- a/tests/twister2_plugin_platform_selection_test.py
+++ b/tests/twister2_plugin_platform_selection_test.py
@@ -9,18 +9,18 @@ import pytest
     [
         (
             '--all',
-            ['*native_posix*', '*qemu_cortex_m3*', '*altera_max10*', '*mps2_an521_remote*'],
-            []
+            ['*native_posix*', '*qemu_cortex_m3*', '*altera_max10*'],
+            ['*mps2_an521_remote*']
         ),
         (
             '--emulation-only',
-            ['*native_posix*', '*qemu_cortex_m3*', '*mps2_an521_remote*'],
-            ['*altera_max10*']
+            ['*native_posix*', '*qemu_cortex_m3*'],
+            ['*altera_max10*', '*mps2_an521_remote*']
         ),
         (
             '--arch=arm',
-            ['*qemu_cortex_m3*', '*mps2_an521_remote*'],
-            ['*native_posix*', '*altera_max10*']
+            ['*qemu_cortex_m3*'],
+            ['*native_posix*', '*altera_max10*', '*mps2_an521_remote*']
         ),
         (
             '--arch=posix --arch=nios2',
@@ -29,8 +29,8 @@ import pytest
         ),
         (
             '',
-            ['*native_posix*', '*mps2_an521_remote*'],
-            ['*qemu_cortex_m3*', '*altera_max10*']
+            ['*native_posix*'],
+            ['*qemu_cortex_m3*', '*altera_max10*', '*mps2_an521_remote*']
         )
     ],
     ids=[
@@ -75,8 +75,8 @@ def test_if_selected_proper_platforms(
         ),
         (
             '--all',
-            ['*native_posix*', '*qemu_cortex_m3*', '*altera_max10*', '*mps2_an521_remote*'],
-            []
+            ['*native_posix*', '*qemu_cortex_m3*', '*altera_max10*'],
+            ['*mps2_an521_remote*']
         )
     ],
     ids=[


### PR DESCRIPTION
Tags are nested in platform.tesing dict and were not collected. Fix tests by adapting to proper logic.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>