### PR TITLE
Align platform scope

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
 sphinx
-sphinx-rtd-theme
-sphinx-docstring-typing
 sphinx-autodoc-typehints
+sphinx-docstring-typing
+sphinx-rtd-theme

--- a/src/twister2/platform_specification.py
+++ b/src/twister2/platform_specification.py
@@ -37,7 +37,6 @@ class PlatformSpecification:
     twister: bool = True
     ram: int = 128  # in kilobytes
     flash: int = 512  # in kilobytes
-    default: bool = False
     supported: set = field(default_factory=set)
     arch: str = ''
     type: str = 'na'  # mcu, qemu, sim, unit, native

--- a/src/twister2/platform_specification.py
+++ b/src/twister2/platform_specification.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 from dataclasses import dataclass, field
 from os import getenv
 from pathlib import Path
@@ -168,3 +169,12 @@ def search_platforms(
             platforms.append(platform_config)
     validate_platforms_list(platforms)
     return platforms
+
+
+def is_simulation_platform_available(simulation_exec: str | None) -> bool:
+    """Check if simulation program is available on the test setup"""
+    if simulation_exec and simulation_exec != 'na':
+        if shutil.which(simulation_exec) is None:
+            logger.debug(f'{simulation_exec} not found.')
+            return False
+    return True

--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -102,6 +102,11 @@ def pytest_addoption(parser: pytest.Parser):
         help='load hardware map from a file',
     )
     twister_group.addoption(
+        '-G', '--integration',
+        action='store_true',
+        help='Run integration tests',
+    )
+    twister_group.addoption(
         '--emulation-only',
         action='store_true',
         help='Only build and run emulation platforms',

--- a/src/twister2/report/helper.py
+++ b/src/twister2/report/helper.py
@@ -49,16 +49,16 @@ def get_item_platform(item: pytest.Item) -> str:
 
 def get_item_platform_allow(item: pytest.Item) -> str:
     """Return allowed platforms."""
-    if hasattr(item.session, 'specification'):
-        if spec := item.session.specification.get(item.nodeid):
+    if hasattr(item.session, 'specifications'):
+        if spec := item.session.specifications.get(item.nodeid):
             return ' '.join(spec.platform_allow)
     return ''
 
 
 def get_item_runnable_status(item: pytest.Item) -> bool:
     """Return runnable status."""
-    if hasattr(item.session, 'specification'):
-        if spec := item.session.specification.get(item.nodeid):
+    if hasattr(item.session, 'specifications'):
+        if spec := item.session.specifications.get(item.nodeid):
             return spec.runnable
     return True
 

--- a/src/twister2/specification_processor.py
+++ b/src/twister2/specification_processor.py
@@ -14,7 +14,10 @@ import pytest
 
 from twister2.exceptions import TwisterConfigurationException
 from twister2.helper import safe_load_yaml
-from twister2.platform_specification import PlatformSpecification
+from twister2.platform_specification import (
+    PlatformSpecification,
+    is_simulation_platform_available,
+)
 from twister2.twister_config import TwisterConfig
 from twister2.yaml_test_function import add_markers_from_specification
 from twister2.yaml_test_specification import (
@@ -418,9 +421,8 @@ def is_runnable(
         return False
 
     for sim in ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native']:
-        if platform.simulation == sim and platform.simulation_exec and platform.simulation_exec != 'na':
-            if shutil.which(platform.simulation_exec) is None:
-                logger.debug(f'{platform.simulation_exec} not found.')
+        if platform.simulation == sim:
+            if not is_simulation_platform_available(platform.simulation_exec):
                 return False
 
     if fixtures is None:

--- a/src/twister2/twister_config.py
+++ b/src/twister2/twister_config.py
@@ -35,7 +35,7 @@ class TwisterConfig:
     integration_mode: bool = False
     emulation_only: bool = False
     architectures: list[str] = field(default_factory=list, repr=False)
-    default_platforms: bool = False
+    default_platforms_only: bool = False
     # platform filter provided by user via --platform argument in CLI or via hardware map file
     user_platform_filter: list[str] = field(default_factory=list, repr=False)
     used_toolchain_version: str = ''
@@ -73,7 +73,7 @@ class TwisterConfig:
 
         # just to keep compatibility with TwisterV1
         # default_platforms will be used to update filered architectures (--arch keyword)
-        default_platforms: bool = not (
+        default_platforms_only: bool = not (
             config.option.all or config.option.platform or config.option.emulation_only
         )
         user_platform_filter: list[str] = config.option.platform
@@ -97,7 +97,7 @@ class TwisterConfig:
             integration_mode=integration_mode,
             emulation_only=emulation_only,
             architectures=architectures,
-            default_platforms=default_platforms,
+            default_platforms_only=default_platforms_only,
             user_platform_filter=user_platform_filter,
             used_toolchain_version=used_toolchain_version,
         )

--- a/src/twister2/twister_config.py
+++ b/src/twister2/twister_config.py
@@ -53,6 +53,7 @@ class TwisterConfig:
         fixtures: list[str] = config.option.fixtures
         extra_args_cli: list[str] = config.getoption('--extra-args')
         overflow_as_errors: bool = config.option.overflow_as_errors
+        integration_mode: bool = config.option.integration
         emulation_only: bool = config.option.emulation_only
         architectures: list[str] = config.option.arch
 
@@ -89,6 +90,7 @@ class TwisterConfig:
             fixtures=fixtures,
             extra_args_cli=extra_args_cli,
             overflow_as_errors=overflow_as_errors,
+            integration_mode=integration_mode,
             emulation_only=emulation_only,
             architectures=architectures,
             default_platforms=default_platforms,

--- a/src/twister2/twister_config.py
+++ b/src/twister2/twister_config.py
@@ -9,7 +9,10 @@ import pytest
 
 from twister2.device.hardware_map import HardwareMap
 from twister2.environment.environment import get_toolchain_version
-from twister2.platform_specification import PlatformSpecification
+from twister2.platform_specification import (
+    PlatformSpecification,
+    is_simulation_platform_available,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -156,9 +159,14 @@ def _get_selected_platforms(config: pytest.Config) -> list[str]:
             platform.identifier for platform in platforms
         ]
     else:
-        selected_platforms = [
-            platform.identifier for platform in platforms
-            if platform.testing.default
-        ]
+        for platform in platforms:
+            if not platform.testing.default:
+                continue
+            # default platforms that can't be run are dropped from the list of
+            # the default platforms list. Default platforms should always be runnable
+            if platform.simulation \
+               and not is_simulation_platform_available(platform.simulation_exec):
+                continue
+            selected_platforms.append(platform.identifier)
 
     return selected_platforms

--- a/src/twister2/yaml_file.py
+++ b/src/twister2/yaml_file.py
@@ -44,6 +44,6 @@ def read_test_specifications_from_yaml(
     """
     processor = YamlSpecificationProcessor(twister_config, filepath)
 
-    for platform, scenario in processor.get_test_variants():
+    for platform, scenario in processor.get_test_configurations():
         if test_spec := processor.process(platform, scenario):
             yield test_spec

--- a/src/twister2/yaml_file.py
+++ b/src/twister2/yaml_file.py
@@ -6,7 +6,6 @@ https://github.com/pytest-dev/pytest/issues/3639
 """
 from __future__ import annotations
 
-import itertools
 import logging
 from pathlib import Path
 from typing import Generator
@@ -45,12 +44,6 @@ def read_test_specifications_from_yaml(
     """
     processor = YamlSpecificationProcessor(twister_config, filepath)
 
-    platforms = (
-        platform for platform in twister_config.platforms
-        if platform.identifier in twister_config.selected_platforms
-    )
-    scenarios: list[str] = processor.scenarios
-
-    for platform, scenario in itertools.product(platforms, scenarios):
+    for platform, scenario in processor.get_test_variants():
         if test_spec := processor.process(platform, scenario):
             yield test_spec

--- a/tests/platfrom_specification_test.py
+++ b/tests/platfrom_specification_test.py
@@ -18,7 +18,7 @@ def test_if_platform_specification_can_be_load_from_yaml_file(resources):
     board_file = resources.joinpath('boards', 'arm', 'mps2_an521', 'mps2_an521_remote.yaml')
     platform = PlatformSpecification.load_from_yaml(board_file)
     assert isinstance(platform, PlatformSpecification)
-    assert isinstance(platform.default, bool)
+    assert isinstance(platform.testing.default, bool)
     assert isinstance(platform.ram, int)
     assert platform.ram == 4096
     assert platform.identifier == 'mps2_an521_remote'

--- a/tests/quarantine/quarantine_unit_test.py
+++ b/tests/quarantine/quarantine_unit_test.py
@@ -1,9 +1,10 @@
 
-import pytest
 import textwrap
 
-from twister2.quarantine_plugin import QuarantineData, QuarantineElement
+import pytest
+
 from twister2.exceptions import TwisterConfigurationException
+from twister2.quarantine_plugin import QuarantineData, QuarantineElement
 
 
 def test_quarantine_load_data(tmp_path):

--- a/tests/specification_processor_test.py
+++ b/tests/specification_processor_test.py
@@ -13,6 +13,7 @@ from twister2.specification_processor import (
     should_skip_for_arch,
     should_skip_for_depends_on,
     should_skip_for_env,
+    should_skip_for_integration_or_emulation,
     should_skip_for_min_flash,
     should_skip_for_min_ram,
     should_skip_for_platform,
@@ -21,7 +22,6 @@ from twister2.specification_processor import (
     should_skip_for_spec_type_unit,
     should_skip_for_tag,
     should_skip_for_toolchain,
-    should_skip_related_with_platform_scope_updates,
 )
 from twister2.yaml_test_specification import YamlTestSpecification
 
@@ -321,40 +321,13 @@ def test_if_test_is_not_runnable_on_windows():
         'not-matched-platform'
     ]
 )
-def test_should_skip_for_unclear_with_integration(
+def test_should_skip_for_integration(
     testcase, platform, twister_config, integration_platforms, expected_result
 ):
     twister_config.integration_mode = True
     platform.identifier = 'platform1'
     testcase.integration_platforms = integration_platforms
-    assert should_skip_related_with_platform_scope_updates(
-        testcase, platform, twister_config) is expected_result
-
-
-@pytest.mark.parametrize(
-    ('is_default, build_an_all, platform_allow, expected_result'),
-    [
-        (True, False, ['platform1'], False),
-        (False, True, [], False),
-        (False, False, [], True),
-        (True, True, [], False),
-    ],
-    ids=[
-        'with-platform-allow',
-        'with-build-on-all',
-        'not-default-platform',
-        'default-platform'
-    ]
-)
-def test_should_skip_for_unclear_with_default_platforms(
-    testcase, platform, twister_config, is_default, build_an_all, platform_allow, expected_result
-):
-    twister_config.default_platforms_only = True
-    platform.testing.default = is_default
-    testcase.platform_allow = platform_allow
-    testcase.build_on_all = build_an_all
-
-    assert should_skip_related_with_platform_scope_updates(
+    assert should_skip_for_integration_or_emulation(
         testcase, platform, twister_config) is expected_result
 
 
@@ -369,10 +342,10 @@ def test_should_skip_for_unclear_with_default_platforms(
         'not-emu-platform'
     ]
 )
-def test_should_skip_for_unclear_with_emulation(
+def test_should_skip_for_emulation(
     testcase, platform, twister_config, simulation, expected_result
 ):
     twister_config.emulation_only = True
     platform.simulation = simulation
-    assert should_skip_related_with_platform_scope_updates(
+    assert should_skip_for_integration_or_emulation(
         testcase, platform, twister_config) is expected_result

--- a/tests/twister2_plugin_platform_selection_test.py
+++ b/tests/twister2_plugin_platform_selection_test.py
@@ -18,14 +18,19 @@ import pytest
             ['*altera_max10*', '*mps2_an521_remote*']
         ),
         (
-            '--arch=arm',
+            '--arch=arm --all',
             ['*qemu_cortex_m3*'],
             ['*native_posix*', '*altera_max10*', '*mps2_an521_remote*']
         ),
         (
-            '--arch=posix --arch=nios2',
+            '--arch=posix --arch=nios2 --all',
             ['*native_posix*', '*altera_max10*'],
             ['*qemu_cortex_m3*', '*mps2_an521_remote*']
+        ),
+        (
+            '--arch=posix --arch=nios2',
+            ['*native_posix*'],
+            ['*altera_max10*', '*qemu_cortex_m3*', '*mps2_an521_remote*']
         ),
         (
             '',
@@ -38,6 +43,7 @@ import pytest
         'emulation-only',
         'arch-arm',
         'select-two-archs',
+        'default-archs',
         'default-platforms'
     ]
 )
@@ -55,6 +61,7 @@ def test_if_selected_proper_platforms(
         runpytest_args.extend(extend_command.split(' '))
     result = pytester.runpytest(*runpytest_args)
 
+    print(result.stdout)
     result.stdout.fnmatch_lines_random(expected)
     for no_line in not_expected:
         result.stdout.no_fnmatch_line(no_line)
@@ -116,6 +123,120 @@ def test_if_selected_proper_platform_with_hardware_map(
         runpytest_args.extend(extend_command.split(' '))
     result = pytester.runpytest(*runpytest_args)
 
+    result.stdout.fnmatch_lines_random(expected)
+    for no_line in not_expected:
+        result.stdout.no_fnmatch_line(no_line)
+
+
+@pytest.mark.parametrize(
+    ('extend_command, expected, not_expected'),
+    [
+        (
+            '--integration',
+            ['*qemu_cortex_m3*'],
+            ['*altera_max10*']
+        ),
+        (
+            '',
+            ['*native_posix*'],
+            ['*altera_max10*', '*qemu_cortex_m3*']
+        ),
+        (
+            '--platform=native_posix',
+            ['*native_posix*'],
+            ['*altera_max10*', '*qemu_cortex_m3*']
+        ),
+        (
+            '--platform=altera_max10',
+            [],
+            ['*altera_max10*', '*qemu_cortex_m3*', '*native_posix*']
+        ),
+        (
+            '--platform=native_posix -G',
+            ['*qemu_cortex_m3*'],
+            ['*altera_max10*', '*native_posix*']
+        ),
+    ],
+    ids=[
+        'integration',
+        'default_from_platform_allow',
+        'platform_selected',
+        'platform_not_alowed',
+        'platform_and_integration'
+    ]
+)
+def test_if_selected_proper_platform_with_testcase_scope(
+        pytester, resources, extend_command, expected, not_expected
+):
+    pytester.copy_example(str(resources))
+    test_sample = pytester.path / 'tests' / 'integration' / 'testcase.yaml'
+    test_sample.parent.mkdir(parents=True)
+    test_sample.write_text(textwrap.dedent("""\
+        tests:
+            sample.test:
+                platform_allow: native_posix qemu_cortex_m3
+                integration_platforms:
+                - qemu_cortex_m3
+    """))
+    runpytest_args = [
+        f'--zephyr-base={str(pytester.path)}',
+        '--collect-only',
+        str(test_sample.parent)
+    ]
+    if extend_command:
+        runpytest_args.extend(extend_command.split(' '))
+    result = pytester.runpytest(*runpytest_args)
+    result.stdout.fnmatch_lines_random(expected)
+    for no_line in not_expected:
+        result.stdout.no_fnmatch_line(no_line)
+
+
+@pytest.mark.parametrize(
+    ('extend_command, expected, not_expected'),
+    [
+        (
+            '',
+            ['*altera_max10*', '*qemu_cortex_m3*', '*native_posix*'],
+            []
+        ),
+        (
+            '--integration',
+            ['*altera_max10*', '*qemu_cortex_m3*', '*native_posix*'],
+            []
+        ),
+        (
+            '--platform=native_posix',
+            ['*native_posix*'],
+            ['*altera_max10*', '*qemu_cortex_m3*']
+        )
+    ],
+    ids=[
+        'all_instead_of_default',
+        'all_instead_of_integration',
+        'platform_selected'
+    ]
+)
+def test_if_selected_proper_platform_with_build_on_all(
+        pytester, resources, extend_command, expected, not_expected
+):
+    pytester.copy_example(str(resources))
+    test_sample = pytester.path / 'tests' / 'build_on_all' / 'testcase.yaml'
+    test_sample.parent.mkdir(parents=True)
+    test_sample.write_text(textwrap.dedent("""\
+        tests:
+            sample.test:
+                build_on_all: true
+    """))
+    runpytest_args = [
+        f'--zephyr-base={str(pytester.path)}',
+        '--collect-only',
+        '--log-level=DEBUG',
+        str(test_sample.parent)
+    ]
+    if extend_command:
+        runpytest_args.extend(extend_command.split(' '))
+    result = pytester.runpytest(*runpytest_args)
+    print(result.stdout)
     result.stdout.fnmatch_lines_random(expected)
     for no_line in not_expected:
         result.stdout.no_fnmatch_line(no_line)

--- a/tests/twister2_plugin_test.py
+++ b/tests/twister2_plugin_test.py
@@ -19,6 +19,7 @@ def test_twister_help(pytester):
         '*--extra-args=EXTRA_ARGS*',
         '*Extra CMake arguments*',
         '*--overflow-as-errors*',
+        '*--integration*',
         '*--emulation-only*',
         '*--arch=ARCH*',
         '*--all*'


### PR DESCRIPTION
* integration mode added `-G, --integration` 
* second phase of selecting platform scope, getting parameters from yaml spec file (`build_on_all`, `platform_allow` etc.)

Try with commands:
```
pytest samples/hello_world -vv --clear=delete --testplan-json=twister-out/testplan.json --collect-only -G
scripts/twister -T samples/hello_world -vv -c --dry-run -G

pytest tests/bluetooth -vv --clear=delete --testplan-json=twister-out/testplan.json --collect-only
scripts/twister -T tests/bluetooth -vv -c --dry-run

pytest tests/kernel/common -vv --clear=delete --testplan-json=twister-out/testplan.json --collect-only -G --arch=posix
scripts/twister -T tests/kernel/common -vv -c --dry-run -G --arch posix
```

 `build_on_all` is set in `tests/kernel/common` so all platforms are added. When using `--arch` platforms are filtered but still in twister1 json log.
In twister2 impementation, we do not keep filtered tests in json log, they can be found in `testcases_creation.log`



Postponed:
* applying platform scope filtering in `pytest_generate_tests` (pytest scenarios)
* mark tests as error when skipped for integration mode