### PR TITLE
Add used toolchain filtration 

### DIFF
--- a/src/twister2/environment/environment.py
+++ b/src/twister2/environment/environment.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from twister2.exceptions import TwisterException
+from twister2.helper import log_command
+
+logger = logging.getLogger(__name__)
+
+
+def get_toolchain_version(output_dir: str, zephyr_base: str) -> str:
+    """
+    When TwisterConfig is generated first time, then information about used
+    toolchain version should be taken by CMake script and then saved into
+    environment_info.json file. In case when xdist is used, then every time when
+    TwisterConfig is generated once again by each worker, information about used
+    toolchain version can be taken from environment_info.json file to avoid
+    calling CMake script several times in row.
+    """
+    environment_info_file_name = 'environment_info.json'
+    environment_info_file_path: Path = Path(output_dir) / environment_info_file_name
+
+    if environment_info_file_path.is_file():
+        used_toolchain_version = _get_toolchain_version_from_env_info_file(environment_info_file_path)
+    else:
+        used_toolchain_version = _get_toolchain_version_from_cmake_script(zephyr_base)
+        _save_toolchain_version_to_env_info_file(environment_info_file_path, used_toolchain_version)
+
+    return used_toolchain_version
+
+
+def _get_toolchain_version_from_env_info_file(file_path: Path) -> str:
+    try:
+        with open(file_path, 'r') as file:
+            environment_info = json.load(file)
+            used_toolchain_version = environment_info['used_toolchain_version']
+    except Exception:
+        logger.error('Problem with get info about used toolchain version.')
+        raise
+    return used_toolchain_version
+
+
+def _save_toolchain_version_to_env_info_file(file_path: Path, toolchain_version: str) -> None:
+    environment_info = {'used_toolchain_version': toolchain_version}
+    with open(file_path, 'w') as file:
+        json.dump(environment_info, file, indent=4)
+
+
+def _get_toolchain_version_from_cmake_script(zephyr_base: str) -> str:
+    """
+    TODO: this function was copied from Twister v1 and requires some refactoring in the future
+    TODO: write unit tests dedicated for this function
+    """
+    toolchain_script = Path(zephyr_base) / 'cmake' / 'verify-toolchain.cmake'
+    result = _run_cmake_script(toolchain_script, ['FORMAT=json'])
+
+    try:
+        if result.get('returncode') != 0:
+            logger.error(result['returnmsg'])
+            pytest.exit(result['returnmsg'], returncode=2)
+    except KeyError:
+        msg = 'Problem with get toolchain version by CMake script.'
+        logger.error(msg)
+        pytest.exit(msg, returncode=2)
+
+    toolchain_version = json.loads(result['stdout'])['ZEPHYR_TOOLCHAIN_VARIANT']
+    logger.info(f"Using '{toolchain_version}' toolchain.")
+    return toolchain_version
+
+
+def _run_cmake_script(script: str | Path, cmake_extra_args: list[str] | None = None) -> dict:
+    """
+    TODO: this function was copied from Twister v1 and requires some refactoring in the future
+    TODO: write unit tests dedicated for this function
+    """
+    if cmake_extra_args is None:
+        cmake_extra_args = []
+
+    script = os.fspath(script)
+
+    logger.debug('Running cmake script %s', script)
+
+    cmake_args = ['-D{}'.format(a.replace('"', '')) for a in cmake_extra_args]
+    cmake_args.extend(['-P', script])
+
+    if (cmake := shutil.which('cmake')) is None:
+        raise TwisterException('cmake not found')
+
+    cmd = [cmake] + cmake_args
+    log_command(logger, 'Calling cmake', cmd)
+
+    # CMake sends the output of message() to stderr unless it's STATUS
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    process_output, _ = p.communicate()
+
+    # It might happen that the environment adds ANSI escape codes like \x1b[0m,
+    # for instance if twister is executed from inside a makefile. In such a
+    # scenario it is then necessary to remove them, as otherwise the JSON decoding
+    # will fail.
+    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    out = ansi_escape.sub('', process_output.decode())
+
+    if p.returncode == 0:
+        msg = f'Finished running {script}'
+        logger.debug(msg)
+        results = {'returncode': p.returncode, 'msg': msg, 'stdout': out}
+
+    else:
+        logger.error('Cmake script failure: %s' % script)
+        results = {'returncode': p.returncode, 'returnmsg': out}
+
+    return results

--- a/src/twister2/twister_config.py
+++ b/src/twister2/twister_config.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from twister2.device.hardware_map import HardwareMap
+from twister2.environment.environment import get_toolchain_version
 from twister2.platform_specification import PlatformSpecification
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,7 @@ class TwisterConfig:
     default_platforms: bool = False
     # platform filter provided by user via --platform argument in CLI or via hardware map file
     user_platform_filter: list[str] = field(default_factory=list, repr=False)
+    used_toolchain_version: str = ''
 
     @classmethod
     def create(cls, config: pytest.Config) -> TwisterConfig:
@@ -73,6 +75,8 @@ class TwisterConfig:
 
         selected_platforms = _get_selected_platforms(config)
 
+        used_toolchain_version = get_toolchain_version(output_dir, zephyr_base)
+
         data: dict[str, Any] = dict(
             zephyr_base=zephyr_base,
             build_only=build_only,
@@ -88,7 +92,8 @@ class TwisterConfig:
             emulation_only=emulation_only,
             architectures=architectures,
             default_platforms=default_platforms,
-            user_platform_filter=user_platform_filter
+            user_platform_filter=user_platform_filter,
+            used_toolchain_version=used_toolchain_version,
         )
         return cls(**data)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -36,3 +37,15 @@ def copy_example(pytester) -> Path:
     resources_dir = Path(__file__).parent / 'data'
     pytester.copy_example(str(resources_dir))
     return pytester.path
+
+
+@pytest.fixture(scope='function', autouse=True)
+def mock_get_toolchain_version():
+    """
+    we need to mock
+    twister2.environment.environment._get_toolchain_version_from_cmake_script
+    because in unit tests we don't have Zephyr repo to call this script
+    """
+    with mock.patch('twister2.environment.environment._get_toolchain_version_from_cmake_script') as mocked_object:
+        mocked_object.return_value = 'zephyr'
+        yield mocked_object

--- a/tests/report/report_plugin_test.py
+++ b/tests/report/report_plugin_test.py
@@ -6,7 +6,7 @@ import pytest
 
 
 def test_if_pytest_generate_testplan_json(pytester, copy_example) -> None:
-    output_testplan: Path = pytester.path / 'tesplan.json'
+    output_testplan: Path = pytester.path / 'testplan.json'
     result = pytester.runpytest(
         str(copy_example),
         f'--zephyr-base={str(copy_example)}',
@@ -16,13 +16,13 @@ def test_if_pytest_generate_testplan_json(pytester, copy_example) -> None:
     )
     assert output_testplan.is_file()
     result.stdout.fnmatch_lines_random([
-        '*generated*results*report*file:*tesplan.json*'
+        '*generated*results*report*file:*testplan.json*'
     ])
 
 
 @pytest.mark.parametrize('extra_args', ['-n 0', '-n 2'], ids=['no_xdist', 'xdist'])
 def test_if_pytest_generate_testplan_csv(pytester, copy_example, extra_args) -> None:
-    output_testplan: Path = pytester.path / 'tesplan.csv'
+    output_testplan: Path = pytester.path / 'testplan.csv'
     result = pytester.runpytest(
         str(copy_example),
         f'--zephyr-base={str(copy_example)}',
@@ -33,7 +33,7 @@ def test_if_pytest_generate_testplan_csv(pytester, copy_example, extra_args) -> 
     )
     assert output_testplan.is_file()
     result.stdout.fnmatch_lines_random([
-        '*generated*results*report*file:*tesplan.csv*'
+        '*generated*results*report*file:*testplan.csv*'
     ])
 
 

--- a/tests/specification_processor_test.py
+++ b/tests/specification_processor_test.py
@@ -97,25 +97,54 @@ def test_should_skip_for_arch_for_arch_exclude_negative(testcase, platform):
 def test_should_skip_for_toolchain_for_toolchain_allow_positive(testcase, platform):
     testcase.toolchain_allow = {'toolchain1'}
     platform.toolchain = ['toolchain2']
-    assert should_skip_for_toolchain(testcase, platform)
+    used_toolchain_version = 'toolchain2'
+    assert should_skip_for_toolchain(testcase, platform, used_toolchain_version)
 
 
 def test_should_skip_for_toolchain_for_toolchain_allow_negative(testcase, platform):
     testcase.toolchain_allow = {'toolchain1'}
     platform.toolchain = ['toolchain1']
-    assert should_skip_for_toolchain(testcase, platform) is False
+    used_toolchain_version = 'toolchain1'
+    assert should_skip_for_toolchain(testcase, platform, used_toolchain_version) is False
 
 
 def test_should_skip_for_toolchain_for_toolchain_exclude_positive(testcase, platform):
     testcase.toolchain_exclude = {'toolchain1', 'toolchain2'}
     platform.toolchain = ['toolchain2']
-    assert should_skip_for_toolchain(testcase, platform)
+    used_toolchain_version = 'toolchain2'
+    assert should_skip_for_toolchain(testcase, platform, used_toolchain_version)
 
 
 def test_should_skip_for_toolchain_for_toolchain_exclude_negative(testcase, platform):
     testcase.toolchain_exclude = {'toolchain2'}
     platform.toolchain = ['toolchain1']
-    assert should_skip_for_toolchain(testcase, platform) is False
+    used_toolchain_version = 'toolchain1'
+    assert should_skip_for_toolchain(testcase, platform, used_toolchain_version) is False
+
+
+def test_should_skip_for_toolchain_for_used_toolchain_positive(testcase, platform):
+    platform.toolchain = ['toolchain1']
+    used_toolchain_version = 'toolchain2'
+    assert should_skip_for_toolchain(testcase, platform, used_toolchain_version)
+
+
+def test_should_skip_for_toolchain_for_used_toolchain_negative(testcase, platform):
+    platform.toolchain = ['toolchain1']
+    used_toolchain_version = 'toolchain1'
+    assert should_skip_for_toolchain(testcase, platform, used_toolchain_version) is False
+
+
+def test_should_skip_for_toolchain_for_used_toolchain_host_negative(testcase, platform):
+    platform.toolchain = ['host']
+    used_toolchain_version = 'toolchain1'
+    assert should_skip_for_toolchain(testcase, platform, used_toolchain_version) is False
+
+
+def test_should_skip_for_toolchain_for_used_toolchain_unit_negative(testcase, platform):
+    testcase.type = 'unit'
+    platform.toolchain = ['toolchain1']
+    used_toolchain_version = 'toolchain2'
+    assert should_skip_for_toolchain(testcase, platform, used_toolchain_version) is False
 
 
 def test_should_skip_for_platform_positive(testcase, platform):

--- a/tests/twister2_plugin_quarantine_test.py
+++ b/tests/twister2_plugin_quarantine_test.py
@@ -18,7 +18,7 @@ def test_if_pytest_use_quarantine_file(pytester, resources) -> None:
     """
     pytester.copy_example(str(resources))
     quarantine_file: Path = resources / 'quarantine' / 'helloworld_native.yml'
-    output_testplan: Path = pytester.path / 'tesplan.json'
+    output_testplan: Path = pytester.path / 'testplan.json'
     pytester.runpytest(
         f'--zephyr-base={str(pytester.path)}',
         '--platform=native_posix',
@@ -45,7 +45,7 @@ def test_if_pytest_use_regex_in_quarantine_files(pytester, resources) -> None:
     """
     pytester.copy_example(str(resources))
     quarantine_file: Path = resources / 'quarantine' / 'regex_example.yml'
-    output_testplan: Path = pytester.path / 'tesplan.json'
+    output_testplan: Path = pytester.path / 'testplan.json'
     pytester.runpytest(
         f'--zephyr-base={str(pytester.path)}',
         '--platform=native_posix',
@@ -72,7 +72,7 @@ def test_if_pytest_use_two_quarantine_files(pytester, resources) -> None:
     pytester.copy_example(str(resources))
     quarantine_file1: Path = resources / 'quarantine' / 'helloworld_native.yml'
     quarantine_file2: Path = resources / 'quarantine' / 'filter_arch_and_plat.yml'
-    output_testplan: Path = pytester.path / 'tesplan.json'
+    output_testplan: Path = pytester.path / 'testplan.json'
     pytester.runpytest(
         f'--zephyr-base={str(pytester.path)}',
         '--platform=native_posix',


### PR DESCRIPTION
To be compatible with v1, Twister should get information about currently used toolchain and use this information during filtration process.

For example if user uses "zephyr" toolchain and platform requires "xcc" toolchain, then tests dedicated for this platform should be skipped.

For example following test should be skipped:
Twister v1
```
./scripts/twister -vv --inline-logs --platform=xt-sim -T samples/hello_world
```

Twister v2
```
pytest -vvs --log-level=INFO -o log_cli=true --platform=xt-sim samples/hello_world
```

`_get_toolchain_version_from_cmake_script` and `_run_cmake_script` were copied directly from Twister v1. It was determined with @PerMac, that at this moment we can omit refactoring and writing unit tests for those fragments.