### PR TITLE
Generate build.log after building

### DIFF
--- a/src/twister2/log_file/build_log_file.py
+++ b/src/twister2/log_file/build_log_file.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from twister2.log_file.log_file_abstract import LogFileAbstract
+
+logger = logging.getLogger(__name__)
+
+
+class BuildLogFile(LogFileAbstract):
+    """Save logs from the building."""
+    name = 'build'
+
+    def __init__(self, build_dir: str | Path) -> None:
+        super().__init__(build_dir=build_dir, name=self.name)
+
+    def handle(self, data: str | bytes) -> None:
+        """
+        :param data: output from building
+        """
+        if data:
+            data = data.decode(encoding=self.default_encoding) if type(data) is bytes else data
+            with open(file=self.filename, mode='a+', encoding=self.default_encoding) as log_file:
+                log_file.write(data)  # type: ignore
+        else:
+            logger.error(msg='Nothing to save into build.log.')

--- a/src/twister2/log_file/log_file_abstract.py
+++ b/src/twister2/log_file/log_file_abstract.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import abc
+import logging
+import os
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class LogFileAbstract(abc.ABC):
+    """Base class for logging files."""
+
+    def __init__(self, build_dir: Path | str, name: str) -> None:
+        self.default_encoding = sys.getdefaultencoding()
+        self.filename = self.get_log_filename(build_dir=build_dir, name=name)
+
+    def get_log_filename(self, build_dir: Path | str, name: str) -> str:
+        """
+        :param build_dir: path to building directory.
+        :param name: name of the logging file.
+        :return: path to logging file
+        """
+        name = name + '.log'
+        filename = os.path.join(build_dir, name)
+        filename = self._normalize_filename_path(filename=filename)
+        return filename
+
+    @staticmethod
+    def _normalize_filename_path(filename: str) -> str:
+        filename = os.path.expanduser(os.path.expandvars(filename))
+        filename = os.path.normpath(os.path.abspath(filename))
+        return filename
+
+    @abc.abstractmethod
+    def handle(self, data: str) -> None:
+        """Save information to logging file."""

--- a/tests/builder/conftest.py
+++ b/tests/builder/conftest.py
@@ -6,13 +6,13 @@ from twister2.builder.west_builder import WestBuilder
 
 
 @pytest.fixture
-def build_config(tmp_path) -> BuildConfig:
+def build_config(tmpdir_factory) -> BuildConfig:
     """Return BuildConfig"""
     return BuildConfig(
         zephyr_base='zephyr',
         source_dir='source',
-        build_dir='build',
-        output_dir=tmp_path,
+        build_dir=tmpdir_factory.mktemp('build'),
+        output_dir=tmpdir_factory.mktemp('output'),
         platform_name='native_posix',
         platform_arch='',  # TODO:
         scenario='bt',

--- a/tests/log_file/build_log_file_test.py
+++ b/tests/log_file/build_log_file_test.py
@@ -1,0 +1,39 @@
+import logging
+import os
+import pytest
+
+from twister2.log_file.build_log_file import BuildLogFile
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def build_log(tmpdir) -> BuildLogFile:
+    build_log = BuildLogFile(build_dir=tmpdir)
+    yield build_log
+
+
+def test_if_filename_is_correct(build_log):
+    assert build_log.filename.endswith('build.log')
+
+
+def test_handle_data_is_str(build_log):
+    msg = 'str message'
+    build_log.handle(data=msg)
+    assert os.path.exists(path=build_log.filename)
+    with open(file=build_log.filename, mode='r') as file:
+        assert file.readline() == 'str message'
+
+
+def test_handle_data_is_byte(build_log):
+    msg = b'bytes message'
+    build_log.handle(data=msg)
+    assert os.path.exists(path=build_log.filename)
+    with open(file=build_log.filename, mode='r') as file:
+        assert file.readline() == 'bytes message'
+
+
+def test_handle_data_is_none(build_log):
+    msg = None
+    build_log.handle(data=msg)
+    assert not os.path.exists(path=build_log.filename)


### PR DESCRIPTION
After each building Twister should store logs from this process. The PR add this functionality.