### PR TITLE
Add support to filter platform by environment variables

### DIFF
--- a/src/twister2/platform_specification.py
+++ b/src/twister2/platform_specification.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from os import getenv
 from pathlib import Path
 from typing import Generator
 
@@ -49,6 +50,9 @@ class PlatformSpecification:
 
     def __post_init__(self):
         self.supported = set(self.supported)
+        for env in self.env:
+            if not getenv(env, None):
+                self.env_satisfied = False
         if isinstance(self.testing, dict):
             self.testing = Testing(**self.testing)
 

--- a/src/twister2/specification_processor.py
+++ b/src/twister2/specification_processor.py
@@ -208,6 +208,7 @@ def should_be_skip(test_spec: YamlTestSpecification, platform: PlatformSpecifica
         should_skip_for_spec_type_unit(test_spec, platform),
         should_skip_for_tag(test_spec, platform),
         should_skip_for_toolchain(test_spec, platform),
+        should_skip_for_env(test_spec, platform),
     ]):
         return True
     return False
@@ -286,6 +287,14 @@ def should_skip_for_pytest_harness(test_spec: YamlTestSpecification, platform: P
 def should_skip_for_spec_type_unit(test_spec: YamlTestSpecification, platform: PlatformSpecification) -> bool:
     if (platform.type == 'unit') != (test_spec.type == 'unit'):
         _log_test_skip(test_spec, platform, 'Unit type tests cannot be executed on regular platforms')
+        return True
+    return False
+
+
+def should_skip_for_env(test_spec: YamlTestSpecification, platform: PlatformSpecification) -> bool:
+    if not platform.env_satisfied:
+        _log_test_skip(test_spec, platform, 'environment variable(s) ({}) not set'.format(
+            ', '.join(platform.env)))
         return True
     return False
 

--- a/tests/specification_processor_test.py
+++ b/tests/specification_processor_test.py
@@ -12,6 +12,7 @@ from twister2.specification_processor import (
     is_runnable,
     should_skip_for_arch,
     should_skip_for_depends_on,
+    should_skip_for_env,
     should_skip_for_min_flash,
     should_skip_for_min_ram,
     should_skip_for_platform,
@@ -197,6 +198,11 @@ def test_should_skip_for_depends_on_positive(testcase, platform):
     testcase.depends_on = {'netif'}
     platform.supported = {'gpio', 'netif:eth'}
     assert should_skip_for_depends_on(testcase, platform) is False
+
+
+def test_should_skip_for_env(testcase, platform):
+    platform.env_satisfied = False
+    assert should_skip_for_env(testcase, platform)
 
 
 @pytest.mark.parametrize('in_put,out_put', [


### PR DESCRIPTION
If `BSIM_OUT_PATH` is not set, test should be skipped:
```
scripts/twister -T samples/hello_world -vv -c --dry-run -p nrf52_bsim
DEBUG   - nrf52_bsim                samples/hello_world/sample.basic.helloworld        SKIPPED: Environment (BSIM_OUT_PATH) not satisfied
```

```
pytest samples/hello_world -vv --clear=delete --collect-only --platform=nrf52_bsim
```


