### PR TITLE
Fix toolchain filtration

### DIFF
--- a/src/twister2/specification_processor.py
+++ b/src/twister2/specification_processor.py
@@ -222,13 +222,13 @@ def should_be_skip(
 def should_skip_for_toolchain(
     test_spec: YamlTestSpecification, platform: PlatformSpecification, used_toolchain_version: str
 ) -> bool:
-    if not platform.toolchain:
-        return False
-    if test_spec.toolchain_allow and not test_spec.toolchain_allow & set(platform.toolchain):
-        _log_test_skip(test_spec, platform, 'platform.toolchain not in testcase.toolchain_allow')
+    if test_spec.toolchain_allow and used_toolchain_version not in test_spec.toolchain_allow:
+        msg = f'currently used toolchain "{used_toolchain_version}" not in testcase.toolchain_allow'
+        _log_test_skip(test_spec, platform, msg)
         return True
-    if test_spec.toolchain_exclude and test_spec.toolchain_exclude & set(platform.toolchain):
-        _log_test_skip(test_spec, platform, 'platform.toolchain in testcase.toolchain_exclude')
+    if test_spec.toolchain_exclude and used_toolchain_version in test_spec.toolchain_exclude:
+        msg = f'currently used toolchain "{used_toolchain_version}" in testcase.toolchain_exclude'
+        _log_test_skip(test_spec, platform, msg)
         return True
     if (used_toolchain_version not in platform.toolchain) \
             and ('host' not in platform.toolchain) \

--- a/tests/specification_processor_test.py
+++ b/tests/specification_processor_test.py
@@ -109,16 +109,16 @@ def test_should_skip_for_toolchain_for_toolchain_allow_negative(testcase, platfo
 
 
 def test_should_skip_for_toolchain_for_toolchain_exclude_positive(testcase, platform):
-    testcase.toolchain_exclude = {'toolchain1', 'toolchain2'}
-    platform.toolchain = ['toolchain2']
-    used_toolchain_version = 'toolchain2'
+    testcase.toolchain_exclude = {'toolchain1'}
+    platform.toolchain = ['toolchain1']
+    used_toolchain_version = 'toolchain1'
     assert should_skip_for_toolchain(testcase, platform, used_toolchain_version)
 
 
 def test_should_skip_for_toolchain_for_toolchain_exclude_negative(testcase, platform):
-    testcase.toolchain_exclude = {'toolchain2'}
-    platform.toolchain = ['toolchain1']
-    used_toolchain_version = 'toolchain1'
+    testcase.toolchain_exclude = {'toolchain1'}
+    platform.toolchain = ['toolchain2']
+    used_toolchain_version = 'toolchain2'
     assert should_skip_for_toolchain(testcase, platform, used_toolchain_version) is False
 
 


### PR DESCRIPTION
During toolchain filtration, `toolchain_allow` and `toolchain_exclude` should be compared with `used_toolchain_version`.

Can be tested with commands:
Twister v1:
```
scripts/twister -T tests/lib/cmsis_dsp/filtering -p native_posix -vv -c --dry-run
```

Twister v2
```
pytest tests/lib/cmsis_dsp/filtering --platform=native_posix -vv --clear=delete --testplan-json=twister-out/testplan.json --collect-only
```