### PR TITLE
Fix enable-slow tests filter for xdist

### DIFF
--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -223,11 +223,7 @@ def pytest_configure(config: pytest.Config):
     if config.getoption('tags'):
         filter_plugin.add_filter(TagFilter(config))
 
-    if not xdist_worker:
-        config.pluginmanager.register(
-            plugin=filter_plugin,
-            name='filter_tests'
-        )
+    config.pluginmanager.register(plugin=filter_plugin, name='filter_tests')
 
     if config.getoption('quarantine_list_path'):
         quarantine_plugin = QuarantinePlugin(config)


### PR DESCRIPTION
Fixed `--enable-slow` filter option with running with xdist plugin.

Signed-off-by: Fundakowski, Lukasz <lukasz.fundakowski@nordicsemi.no>