### PR TITLE
Add runtime cleanup artifacts

### DIFF
--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -182,6 +182,23 @@ def pytest_addoption(parser: pytest.Parser):
         action='store_true',
         help='Treat memory overflows as errors.'
     )
+    twister_group.addoption(
+        '-M', '--runtime-artifact-cleanup',
+        choices=('pass', 'all'),
+        help='Cleanup test artifacts. "pass" option only removes artifacts of '
+             'passing or skipping tests. If you wish to remove all artifacts '
+             'including those of failed tests, use "all".'
+    )
+    twister_group.addoption(
+        '--prep-artifacts-for-testing',
+        default=False,
+        action='store_true',
+        help='Prepare artifacts for testing - remove unnecessary files after '
+             'application building and keep only this one which are crucial to '
+             'run tests. Additionally sanitize those files from local Zephyr '
+             'base paths to be able to use those artifacts on another host/'
+             'computer/server.'
+    )
 
 
 def pytest_configure(config: pytest.Config):
@@ -287,3 +304,17 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
         item.user_properties.append(('tags', ' '.join(marker.args)))
     if marker := item.get_closest_marker('platform'):
         item.user_properties.append(('platform', marker.args[0]))
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_makereport(item, call):
+    """
+    Hook used to store information about failed test, which can be used in
+    fixture's teardown. Example of use in fixture:
+    test_failed = getattr(request.node, '_test_failed', False)
+    """
+    outcome = yield
+    report = outcome.get_result()
+    if report.failed:
+        setattr(item, '_test_failed', True)
+    return report

--- a/tests/twister2_plugin_test.py
+++ b/tests/twister2_plugin_test.py
@@ -22,7 +22,9 @@ def test_twister_help(pytester):
         '*--integration*',
         '*--emulation-only*',
         '*--arch=ARCH*',
-        '*--all*'
+        '*--all*',
+        '*-M {pass,all}, --runtime-artifact-cleanup={pass,all}*',
+        '*--prep-artifacts-for-testing*'
     ])
 
 


### PR DESCRIPTION
Add functionality of cleaning unecessary artifacts when test is finished. This helps a lot to reduce used memory space during running huge amount of tests.

Can be tested by:
```
pytest --platform=native_posix --runtime-artifact-cleanup=all samples/hello_world 
```

**Warning!**
--
Due to different way how arguments are parsed in Twister v2 (pytest) it is not possible to use `--runtime-artifact-cleanup` without passing `pass` or `all` parameter (like in Twister v1):
```
pytest --platform=native_posix --runtime-artifact-cleanup samples/hello_world
pytest --platform=native_posix -M samples/hello_world
```
The only safe and acceptable option is pass implicate value of parameter, like:
```
pytest --platform=native_posix --runtime-artifact-cleanup=all samples/hello_world
pytest --platform=native_posix --runtime-artifact-cleanup=pass samples/hello_world
pytest --platform=native_posix --runtime-artifact-cleanup all samples/hello_world
pytest --platform=native_posix --runtime-artifact-cleanup pass samples/hello_world
pytest --platform=native_posix -M=all samples/hello_world
pytest --platform=native_posix -M=pass samples/hello_world
pytest --platform=native_posix -M all samples/hello_world
pytest --platform=native_posix -M pass samples/hello_world
```
