### PR TITLE
Add support for platform revisions

### DIFF
--- a/tests/data/boards/arm/stm32f411e_disco/stm32f411e_disco.yaml
+++ b/tests/data/boards/arm/stm32f411e_disco/stm32f411e_disco.yaml
@@ -1,0 +1,10 @@
+identifier: stm32f411e_disco
+name: ST STM32F411E Discovery
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+supported:
+  - counter

--- a/tests/data/boards/arm/stm32f411e_disco/stm32f411e_disco_B.conf
+++ b/tests/data/boards/arm/stm32f411e_disco/stm32f411e_disco_B.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/data/boards/arm/stm32f411e_disco/stm32f411e_disco_D.conf
+++ b/tests/data/boards/arm/stm32f411e_disco/stm32f411e_disco_D.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Some platforms have defined revisions and Twister should recognize them as separate platforms (with @ sign in their name).

Signed-off-by: Lukasz Fundakowski <lukasz.fundakowski@nordicsemi.no>