### PR TITLE
test_results: fix duration and message collection

### DIFF
--- a/src/twister2/log_parser/ztest_log_parser.py
+++ b/src/twister2/log_parser/ztest_log_parser.py
@@ -97,7 +97,7 @@ class ZtestLogParser(LogParserAbstract):
         if self.subtests_fixture is None:
             return
 
-        with self.subtests_fixture.test(msg=subtest.testname):
+        with self.subtests_fixture.test(msg=subtest.testname, ztest_testcase_duration=subtest.duration):
             if subtest.result == SubTestStatus.SKIP:
                 pytest.skip('Skipped on runtime')
             if subtest.result == SubTestStatus.BLOCK:


### PR DESCRIPTION
When subtests were used, then the information about performed test was wrongly taken from first subtest. In this commit it was fixed and calculation of whole test duration (building + execution) is now set properly.

To analyze:
run Twister by command:
```
pytest --platform=native_posix tests/kernel/queue/
```

Fragment of json report **with** changes proposed in this PR:
```
    "tests": [
        {
            "suite_name": "tests.kernel.queue.testcase.yaml",
            "test_name": "kernel.queue[native_posix]",
            "nodeid": "tests/kernel/queue/testcase.yaml::kernel.queue[native_posix]",
            "platform": "native_posix",
            ...
            "status": "passed",
            "message": "",
            "duration": 4.71,
            "execution_time": 0.01,
            "subtests": [
                {
                    "name": "access_kernel_obj_with_priv_data",
                    "status": "passed",
                    "execution_time": 0.00
                },
                ...
```

Fragment of json report **without** changes proposed in this PR (test `duration` and `execution_time` have the same value as `duration` of first subtest):
```
    "tests": [
        {
            "suite_name": "tests.kernel.queue.testcase.yaml",
            "test_name": "kernel.queue[native_posix]",
            "nodeid": "tests/kernel/queue/testcase.yaml::kernel.queue[native_posix]",
            "platform": "native_posix",
            ...
            "status": "passed",
            "message": "",
            "duration": 0.0,
            "execution_time": 0.0,
            "subtests": [
                {
                    "name": "access_kernel_obj_with_priv_data",
                    "status": "passed",
                    "duration": 0.0
                },
                ...
```

fixes: #121 