### PR TITLE
reporting: Customize reporting of yaml tests and subtests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,3 +185,25 @@ List default platforms only:
 .. code-block:: sh
 
   twister_tools --list-platforms --default-only
+
+WARNING
+-------
+
+Our plugin requires pytest-subtest plugin, however, we modify the behavior of "subtests" introduced with this plugin.
+The original implementation is based on subtest concept from unittest framework where such items are counted and reported
+in a peculiar way.
+
+The fact that we modify the behavior of subtests in our plugin can influence users who are using unittest-based subtests in other
+projects. After adding our plugin to their existing environment the reporting of their existing subtests can change. To mitigate such issues
+we recommend running different projects in different virtual environments.
+
+Additional context: Twister defines 2 levels of "test items":
+
+* test suites (configurations) that correspond to built test applications
+
+* test cases that correspond to individual ztest test cases within test applications using ztest framework.
+
+In our plugin, we modified the reporting and counting of subtests to match how twister is doing it. Test suites
+are "tests" in pytest nomenclature and ztest test cases are based on subtests but they don't follow original unittest rules.
+E.g. in unittest, when a subtest fails it is counted towards failing tests but when it passes it is not counted towards tests.
+In our implementation, tests, and subtests have their own counters. I.e. subtests counts are not "leaking" into tests counts.

--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -28,6 +28,7 @@ pytest_plugins = (
     'twister2.generate_tests_plugin',
     'twister2.report.test_plan_plugin',
     'twister2.report.test_results_plugin',
+    'twister2.report.yaml_test_reporting_plugin',
 )
 
 

--- a/src/twister2/report/yaml_test_reporting_plugin.py
+++ b/src/twister2/report/yaml_test_reporting_plugin.py
@@ -1,0 +1,50 @@
+
+""" This plugin modifies the default console output for yaml
+tests and subtests (testcases) when verbosity >=2."""
+
+from __future__ import annotations
+
+import pytest
+from pytest_subtests import SubTestReport
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_report_teststatus(report, config):
+
+    if hasattr(report, 'wasxfail'):
+        return None
+
+    # Do nothing extra if the hook was called for other than yaml/subtest reporting.
+    if report.when != 'call' or '.yaml' not in report.fspath and not isinstance(report, SubTestReport):
+        return None
+
+    # report.location[0] is used when verbosity >=2. By default plugin is printing noise for (yaml/sub)tests
+    if not isinstance(report, SubTestReport):
+        # this change the useless path to "configuration" to differentiate from "ztestcase" printed by subtests
+        # the rest is not changed and pytest_report_teststatus from pytest is further processing the report
+        loc = list(report.location)
+        loc[0] = 'configuration'
+        report.location = tuple(loc)
+        return None
+
+    else:
+        # this change the useless path to (sub)testcase name
+        loc = list(report.location)
+        loc[0] = f'ztestcase "{report.context.msg}"'
+        report.location = tuple(loc)
+
+        output_formating = {
+            'passed': ['subtests passed', ',', 'SUBPASS'],
+            'skipped': ['subtests skipped', '-', 'SUBSKIP'],
+            'failed': ['subtests failed', 'f', 'SUBFAIL'],
+        }
+        # We only want to see subtests' status in the console if verbosity > 1."""
+        # This removes the substatuses from console outputs if verbosity <= 1
+        if config.option.verbose <= 1:
+            for key in output_formating.keys():
+                output_formating[key][1] = ''
+                output_formating[key][2] = ''
+
+        # No further hooks to this plugin (in particular the original pytest pytest_report_teststatus)
+        # are executed after firts non-None return)
+        return tuple(output_formating[report.outcome])

--- a/tests/report/report_plugin_test.py
+++ b/tests/report/report_plugin_test.py
@@ -67,10 +67,6 @@ def test_if_pytest_generates_json_results_with_expected_data(pytester, extra_arg
         def test_error(make_error):
             pass
 
-        def test_subtests(subtests):
-            for i in range(5):
-                with subtests.test(msg="custom message", i=i):
-                    assert i % 2 == 0
     """)
     test_file = pytester.path / 'foobar_test.py'
     test_file.write_text(test_file_content)
@@ -82,12 +78,12 @@ def test_if_pytest_generates_json_results_with_expected_data(pytester, extra_arg
         extra_args
     )
 
-    result.assert_outcomes(passed=2, failed=3, errors=1, xfailed=1, xpassed=1, skipped=1)
+    result.assert_outcomes(passed=1, failed=1, errors=1, xfailed=1, xpassed=1, skipped=1)
     assert output_result.is_file()
     with output_result.open() as file:
         report_data = json.load(file)
     assert set(report_data.keys()) == {'tests', 'environment', 'configuration', 'summary'}
-    assert len(report_data['tests']) == 7
+    assert len(report_data['tests']) == 6
     assert set(report_data['tests'][0].keys()) == {
         'suite_name',
         'test_name',
@@ -104,16 +100,16 @@ def test_if_pytest_generates_json_results_with_expected_data(pytester, extra_arg
     }
     assert report_data['summary'] == {
         'passed': 1,
-        'failed': 2,
+        'failed': 1,
         'skipped': 1,
         'xfailed': 1,
         'xpassed': 1,
         'error': 1,
-        'total': 7,
-        'subtests_total': 5,
-        'subtests_passed': 3,
-        'subtests_failed': 2,
-        'subtests_skipped': 0
+        'total': 6,
+        'subtests_failed': 0,
+        'subtests_passed': 0,
+        'subtests_skipped': 0,
+        'subtests_total': 0
     }
     assert set(report_data['environment'].keys()) == {
         'os',


### PR DESCRIPTION
Subtests are no longer counted towards regular tests. Especially, subtest failures are no longer added to regular failures. Unit tests were adapted accordingly.
Modify how statuses of yaml tests and subtests are reported to console. Subtests are only printed when verbosity > 1. Also, when verbosity>1, replace useless path ro yaml_test_function.py with comment telling if it was a yaml test (aka configuration) or ztestcase.