### PR TITLE
reporting: get closer to V1 format of json report

### DIFF
--- a/src/twister2/report/helper.py
+++ b/src/twister2/report/helper.py
@@ -3,6 +3,9 @@ Module contains helper function used in report package.
 """
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import pytest
 
 
@@ -13,7 +16,41 @@ def get_suite_name(item: pytest.Item) -> str:
     elif hasattr(item, 'module') and hasattr(item.module, '__name__'):
         return f'{item.module.__name__}'
     else:
-        return item.parent.nodeid.replace('/', '.').replace('\\', '.')  # type: ignore[union-attr]
+        # TODO: Below is a copy of workflow used in TestSuite.get_unique() from V1 to achieve name parity.
+
+        # Use this for internal comparisons; that's what canonicalization is
+        # for. Don't use it when invoking other components of the build system
+        # to avoid confusing and hard to trace inconsistencies in error messages
+        # and logs, generated Makefiles, etc. compared to when users invoke these
+        # components directly.
+        # Note "normalization" is different from canonicalization, see os.path.
+        canonical_zephyr_base = os.path.realpath(item.config.twister_config.zephyr_base)
+        suite_root = os.path.abspath(item.path.parent)
+        suite_path = os.path.dirname(item.path)
+        workdir = os.path.relpath(suite_path, suite_root)
+        name = item.originalname
+        return get_suite_name_v1_style(suite_root, workdir, name, canonical_zephyr_base)  # type: ignore[union-attr]
+
+
+def get_suite_name_v1_style(testsuite_root, workdir, name, canonical_zephyr_base) -> str:
+    """Return exact same name as in V1. Copy 1:1 of V1 TestSuite.get_unique()"""
+
+    canonical_testsuite_root = os.path.realpath(testsuite_root)
+    if Path(canonical_zephyr_base) in Path(canonical_testsuite_root).parents:
+        # This is in ZEPHYR_BASE, so include path in name for uniqueness
+        relative_ts_root = os.path.relpath(canonical_testsuite_root, start=canonical_zephyr_base)
+    else:
+        relative_ts_root = ''
+
+    # workdir can be "."
+    unique = os.path.normpath(os.path.join(relative_ts_root, workdir, name))
+    check = name.split('.')
+    if len(check) < 2:
+        raise Exception(f"""bad test name '{name}' in {testsuite_root}/{workdir}. \
+Tests should reference the category and subsystem with a dot as a separator.
+                """
+                        )
+    return unique
 
 
 def get_test_name(item: pytest.Item) -> str:
@@ -37,6 +74,23 @@ def get_item_platform(item: pytest.Item) -> str:
     """Return test platform."""
     if marker := item.get_closest_marker('platform'):
         return marker.args[0]
+    return ''
+
+
+def get_item_arch(item: pytest.Item) -> str:
+    """Return test platform arch."""
+    platform_name = get_item_platform(item)
+    if platform_name:
+        platform_obj = item.config.twister_config.get_platform(platform_name)
+        return platform_obj.arch
+    return ''
+
+
+def get_run_id(item: pytest.Item) -> str:
+    """Return run id."""
+    if hasattr(item.session, 'specifications'):
+        if spec := item.session.specifications.get(item.nodeid):
+            return spec.run_id
     return ''
 
 

--- a/src/twister2/report/test_plan_plugin.py
+++ b/src/twister2/report/test_plan_plugin.py
@@ -12,6 +12,7 @@ from _pytest.terminal import TerminalReporter
 
 from twister2.report.base_report_writer import BaseReportWriter
 from twister2.report.helper import (
+    get_item_arch,
     get_item_build_only_status,
     get_item_platform,
     get_item_runnable_status,
@@ -44,13 +45,15 @@ class TestPlanPlugin:
     def _item_as_dict(self, item: pytest.Item) -> dict:
         """Return test metadata as dictionary."""
         return dict(
-            suite_name=get_suite_name(item),
-            test_name=get_test_name(item),
-            path=get_test_path(item),
+            name=get_suite_name(item),
+            arch=get_item_arch(item),
             platform=get_item_platform(item),
+            runnable=get_item_runnable_status(item),
+            test_name=get_test_name(item),
+            nodeid=item.nodeid,
             type=get_item_type(item),
             build_only=get_item_build_only_status(item),
-            runnable=get_item_runnable_status(item),
+            path=get_test_path(item)
         )
 
     def generate(self, items: List[pytest.Item]) -> dict:

--- a/tests/report/report_plugin_test.py
+++ b/tests/report/report_plugin_test.py
@@ -82,21 +82,23 @@ def test_if_pytest_generates_json_results_with_expected_data(pytester, extra_arg
     assert output_result.is_file()
     with output_result.open() as file:
         report_data = json.load(file)
-    assert set(report_data.keys()) == {'tests', 'environment', 'configuration', 'summary'}
-    assert len(report_data['tests']) == 6
-    assert set(report_data['tests'][0].keys()) == {
-        'suite_name',
+    assert set(report_data.keys()) == {'testsuites', 'environment', 'configuration', 'summary'}
+    assert len(report_data['testsuites']) == 6
+    assert set(report_data['testsuites'][0].keys()) == {
+        'name',
         'test_name',
         'nodeid',
         'platform',
+        'arch',
         'type',
         'build_only',
         'runnable',
+        'run_id',
         'status',
         'duration',
         'execution_time',
         'message',
-        'subtests',
+        'testcases',
     }
     assert report_data['summary'] == {
         'passed': 1,


### PR DESCRIPTION
Rename tests->testsuites and subtests->testcases fields.
Add arch and run_id fields. Adapt tests.