### PR TITLE
requirements: add rerunfailures and split packages

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,3 +1,5 @@
 pytest>=7.0.0
 pytest-cov
+pytest-rerunfailures==11.0
+pytest-split
 pytest-xdist


### PR DESCRIPTION
rerunfailures and split packages are necessary during running Twister in CI, so they should be added to requirements.