### PR TITLE
config: Expand \~ in zephyr_base from user args

### DIFF
--- a/src/twister2/twister_config.py
+++ b/src/twister2/twister_config.py
@@ -48,7 +48,7 @@ class TwisterConfig:
     @classmethod
     def create(cls, config: pytest.Config) -> TwisterConfig:
         """Create new instance from pytest.Config."""
-        zephyr_base: str = (
+        zephyr_base: str = os.path.expanduser(
             config.option.zephyr_base
             or config.getini('zephyr_base')
             or os.environ.get('ZEPHYR_BASE', '')


### PR DESCRIPTION
When twister_config is created the valuses from config are taken "as they are". This caused problems when \~ was is in zephyr_base. It was not expanded and certain modules using zephyr_base from config are failing, e.g. cmake_filter. This patch fixes the issue by expanding the path before it is added to twister_config