### PR TITLE
Add --twister flag to enable plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,11 +66,18 @@ Show all available options:
   pytest --help
 
 
+To use the plugin in a pytest run, simply add `--twister` to the command line invocation:
+
+.. code-block:: sh
+
+  pytest --twister ...
+
+
 Run tests:
 
 .. code-block:: sh
 
-  pytest <PATHS_TO_SCAN_FOR_TEST> -v --zephyr-base=<PATH_TO_ZEPHYR> --platform=native_posix --tb=no
+  pytest --twister <PATHS_TO_SCAN_FOR_TEST> -v --zephyr-base=<PATH_TO_ZEPHYR> --platform=native_posix --tb=no
 
 
 ``<PATHS_TO_SCAN_FOR_TEST>`` can be e.g. ``tests/kernel/common samples/hello_world``
@@ -103,28 +110,28 @@ Show what fixtures and tests would be executed but don't execute anything:
 
 .. code-block:: sh
 
-  pytest tests --setup-plan
+  pytest --twister tests --setup-plan
 
 
 List all tests without executing:
 
 .. code-block:: sh
 
-  pytest tests --collect-only
+  pytest --twister tests --collect-only
 
 
 Run tests only for specific platforms:
 
 .. code-block:: sh
 
-  pytest tests --platform=native_posix --platform=nrf52840dk_nrf52840
+  pytest --twister tests --platform=native_posix --platform=nrf52840dk_nrf52840
 
 
 Provide directory to search for board configuration files:
 
 .. code-block:: sh
 
-  pytest tests --board-root=path_to_board_dir
+  pytest --twister tests --board-root=path_to_board_dir
 
 
 Reports
@@ -134,21 +141,21 @@ Generate test plan in CSV format:
 
 .. code-block:: sh
 
-  pytest tests --testplan-csv=testplan.csv --collect-only
+  pytest --twister tests --testplan-csv=testplan.csv --collect-only
 
 
 Use custom path for test plan in JSON format:
 
 .. code-block:: sh
 
-  pytest tests --testplan-json=custom_plan.json --collect-only
+  pytest --twister tests --testplan-json=custom_plan.json --collect-only
 
 
 Use custom path for result report in JSON format:
 
 .. code-block:: sh
 
-  pytest tests --resutls-json=custom_name.json
+  pytest --twister tests --resutls-json=custom_name.json
 
 
 Filtering tests
@@ -158,7 +165,7 @@ Run tests with given tags (`@` is optional and can be omitted):
 
 .. code-block:: sh
 
-  pytest tests --tags=@tag1,@tag2
+  pytest --twister tests --tags=@tag1,@tag2
 
 
 Examples of usage:

--- a/src/twister2/environment/environment.py
+++ b/src/twister2/environment/environment.py
@@ -122,12 +122,12 @@ def _run_cmake_script(script: str | Path, cmake_extra_args: list[str] | None = N
     return results
 
 
-def get_zephyr_repo_info() -> tuple[str, str]:
+def get_zephyr_repo_info(zephyr_base: str) -> tuple[str, str]:
     class RepoInfo(NamedTuple):
         zephyr_version: str
         commit_date: str
 
-    repo = Repo(os.getenv('ZEPHYR_BASE'))
+    repo = Repo(zephyr_base)
     zephyr_version = repo.head.commit.hexsha[:12]
     commit_date = repo.head.commit.authored_datetime.isoformat(timespec='seconds')
     return RepoInfo(zephyr_version, commit_date)

--- a/src/twister2/report/test_plan_plugin.py
+++ b/src/twister2/report/test_plan_plugin.py
@@ -105,6 +105,9 @@ def pytest_configure(config: pytest.Config):
     if hasattr(config, 'workerinput'):  # xdist worker
         return
 
+    if not (config.getoption('twister') or config.getini('twister')):
+        return
+
     test_plan_writers: list[BaseReportWriter] = []
     testplan_json_path = None
     if config.getoption('testplan_json_path'):

--- a/src/twister2/report/test_results_plugin.py
+++ b/src/twister2/report/test_results_plugin.py
@@ -242,7 +242,7 @@ class TestResultsPlugin:
 
     def _get_environment(self) -> dict:
         duration = self.session_finish_time - self.session_start_time
-        repo_info = get_zephyr_repo_info()
+        repo_info = get_zephyr_repo_info(self.config.twister_config.zephyr_base)
         toolchain = get_toolchain_version(self.config.twister_config.output_dir, self.config.twister_config.zephyr_base)
 
         environment = dict(
@@ -275,6 +275,9 @@ def pytest_addoption(parser: pytest.Parser):
 
 def pytest_configure(config: pytest.Config):
     if hasattr(config, 'workerinput'):  # xdist worker
+        return
+
+    if not (config.getoption('twister') or config.getini('twister')):
         return
 
     test_results_writers = []

--- a/src/twister2/report/yaml_test_reporting_plugin.py
+++ b/src/twister2/report/yaml_test_reporting_plugin.py
@@ -11,6 +11,9 @@ from pytest_subtests import SubTestReport
 @pytest.hookimpl(tryfirst=True)
 def pytest_report_teststatus(report, config):
 
+    if not hasattr(config, 'twister_config'):
+        return
+
     if hasattr(report, 'wasxfail'):
         return None
 

--- a/src/twister2/yaml_file.py
+++ b/src/twister2/yaml_file.py
@@ -17,7 +17,18 @@ from twister2.twister_config import TwisterConfig
 from twister2.yaml_test_function import YamlFunction, yaml_test_function_factory
 from twister2.yaml_test_specification import YamlTestSpecification
 
+SAMPLE_FILENAME: str = 'sample.yaml'
+TESTCASE_FILENAME: str = 'testcase.yaml'
+
 logger = logging.getLogger(__name__)
+
+
+class YamlPytestPlugin():
+
+    def pytest_collect_file(self, parent, path):
+        # discovers all yaml tests in test directory
+        if path.basename in (SAMPLE_FILENAME, TESTCASE_FILENAME):
+            return YamlModule.from_parent(parent, path=Path(path))
 
 
 class YamlModule(pytest.File):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,8 +58,10 @@ def mock_get_zephyr_repo_info():
     we need to mock
     twister2.environment.environment.get_zephyr_repo_info
     because in unit tests we don't have Zephyr repo to call this script
+    comment: when using `from module import method_to_mock`, this method
+        must be mocked using name of current module
     """
-    with mock.patch('twister2.environment.environment.get_zephyr_repo_info') as mocked_object:
+    with mock.patch('twister2.report.test_results_plugin.get_zephyr_repo_info') as mocked_object:
         RepoInfo = namedtuple('RepoInfo', 'zephyr_version commit_date')
         mocked_object.return_value = RepoInfo('123456789012', '20220102')
         yield mocked_object

--- a/tests/data/pytest.ini
+++ b/tests/data/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+twister = True

--- a/tests/filter/filter_plugin_test.py
+++ b/tests/filter/filter_plugin_test.py
@@ -28,6 +28,7 @@ def test_if_all_filters_are_correctly_applied(pytester, extra_args):
             """)
     )
     result = pytester.runpytest(
+        '--twister',
         '--tags=@tag1',
         '--tags=~@tag3',
         '-v',

--- a/tests/report/report_plugin_test.py
+++ b/tests/report/report_plugin_test.py
@@ -73,6 +73,7 @@ def test_if_pytest_generates_json_results_with_expected_data(pytester, extra_arg
     output_result: Path = pytester.path / 'twister.json'
 
     result = pytester.runpytest(
+        '--twister',
         f'--zephyr-base={str(pytester.path)}',
         f'--results-json={output_result}',
         extra_args

--- a/tests/twister2_plugin_quarantine_test.py
+++ b/tests/twister2_plugin_quarantine_test.py
@@ -98,8 +98,8 @@ def test_if_pytest_handle_quarantine_verify(pytester, resources) -> None:
 
 
 @pytest.mark.skip('Quarnatine not supported for pytest scenarios without test specification')
-def test_quarantine_for_python_tests(pytester, tmp_path):
-    quarantine_file = tmp_path / 'quarantine.yml'
+def test_quarantine_for_python_tests(pytester):
+    quarantine_file = pytester.path / 'quarantine.yml'
     quarantine_file.write_text(textwrap.dedent("""\
       - scenarios:
           - test_quarantine_1
@@ -139,8 +139,8 @@ def test_quarantine_for_python_tests(pytester, tmp_path):
     result.assert_outcomes(passed=2)
 
 
-def test_quarantine_for_empty_file(pytester, tmp_path):
-    quarantine_file = tmp_path / 'quarantine.yml'
+def test_quarantine_for_empty_file(pytester):
+    quarantine_file = pytester.path / 'quarantine.yml'
     quarantine_file.write_text(textwrap.dedent("""\
       # empty quarantine
     """))
@@ -153,6 +153,7 @@ def test_quarantine_for_empty_file(pytester, tmp_path):
             """)
     )
     result = pytester.runpytest(
+        '--twister',
         '-v',
         '--zephyr-base=.',
         f'--quarantine-list={quarantine_file}'

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,3 @@ commands_pre = python -c "import shutil; shutil.rmtree('build/html', ignore_erro
 commands =
 	sphinx-apidoc -o docs/.apidoc src/twister2 -l -F
 	sphinx-build -a -E -j auto -b html -n docs build/html -v -T
-
-
-[pytest]
-addopts = -p no:twister


### PR DESCRIPTION
To use twister one must enable it with `--twister` flag:
```
pytest --twister samples/hello_world -G --co
```
or just add it to pytest.ini file
```
[pytest]
twister = True
# or
#addopts = --twister
```