### PR TITLE
Align hardware map generated file with twister1

### DIFF
--- a/src/twister2/device/hardware_map.py
+++ b/src/twister2/device/hardware_map.py
@@ -18,7 +18,7 @@ class HardwareMap:
     notes: str = ''
     probe_id: str = ''
     serial: str = ''
-    baud: str = '115200'
+    baud: int = 115200
     pre_script: str = ''
     post_script: str = ''
     post_flash_script: str = ''
@@ -28,8 +28,16 @@ class HardwareMap:
     def read_from_file(cls, filename: str | Path) -> list[HardwareMap]:
         with open(filename, 'r', encoding='UTF-8') as file:
             data = yaml.safe_load(file)
+        if not data:
+            return []
         return [cls(**hardware) for hardware in data]
 
     def asdict(self):
         """Return hardware map dict valid for map file."""
-        return asdict(self)
+        not_excluded = ['connected', 'serial']
+        return asdict(
+            self,
+            dict_factory=lambda x: {
+                k: v for (k, v) in x if v or k in not_excluded
+            }
+        )

--- a/src/twister2/scripts/__main__.py
+++ b/src/twister2/scripts/__main__.py
@@ -42,7 +42,6 @@ def main() -> int:
     if args.hardware_map_path:
         hardware_map_list = scan(persistent=args.persistent)
         write_to_file(hardware_map_list=hardware_map_list, filename=args.hardware_map_path)
-        print_hardware_map(hardware_map_list)
         return 0
     if args.list_hardware_map:
         hardware_map_list = scan(persistent=args.persistent)

--- a/src/twister2/scripts/hardware_map.py
+++ b/src/twister2/scripts/hardware_map.py
@@ -122,6 +122,7 @@ def scan(persistent: bool = False) -> list[HardwareMap]:
 def write_to_file(filename: str | Path, hardware_map_list: list[HardwareMap]) -> None:
     """Save hardware map to file."""
     new_hardware_map_list = hardware_map_list
+    new_hardware_map_list.sort(key=lambda x: x.serial or '')
     merged_hardware_map_list = []
 
     # update existing hardware map
@@ -152,6 +153,8 @@ def write_to_file(filename: str | Path, hardware_map_list: list[HardwareMap]) ->
         hardware_map_list_as_dict = [device.asdict() for device in merged_hardware_map_list]
         yaml.dump(hardware_map_list_as_dict, file, Dumper=yaml.Dumper, default_flow_style=False)
         logger.info('Saved as %s', filename)
+
+    print_hardware_map(merged_hardware_map_list)
 
 
 def filter_hardware_map(
@@ -196,7 +199,7 @@ def print_hardware_map(hardware_map_list: Iterable[HardwareMap]) -> None:
     headers = ['platform', 'id', 'serial']
     table = (
         (hardware.platform, hardware.id, hardware.serial)
-        for hardware in hardware_map_list
+        for hardware in hardware_map_list if hardware.connected
     )
 
     print()

--- a/src/twister2/twister_config.py
+++ b/src/twister2/twister_config.py
@@ -72,7 +72,9 @@ class TwisterConfig:
         if hardware_map_file:
             hardware_map_list = HardwareMap.read_from_file(filename=hardware_map_file)
             if not config.option.platform:
-                config.option.platform = [p.platform for p in hardware_map_list if p.connected]
+                config.option.platform = [
+                    p.platform for p in hardware_map_list if p.connected and p.platform != 'unknown'
+                ]
 
         if config.option.all:
             # When --all used, any --platform arguments ignored

--- a/tests/scripts/hardware_map_test.py
+++ b/tests/scripts/hardware_map_test.py
@@ -201,3 +201,14 @@ def test_if_hardware_map_can_update_existing_hardware_map(tmp_path):
     assert {hw['id'] for hw in data} == {'id1'}
     assert {hw['connected'] for hw in data} == {True}
     assert {hw['serial'] for hw in data} == {'/dev/ttyACM2', '/dev/ttyACM3'}
+
+
+def test_if_hardware_map_can_be_saved_to_empty_file(tmp_path, hm_list):
+    hm_file = tmp_path / 'hardware-map.yaml'
+    hm_file.write_text('')
+    hardware_map.write_to_file(hm_file, hm_list)
+
+    data = yaml.safe_load(hm_file.read_text())
+    assert len(data) == 2
+    assert {hw['id'] for hw in data} == {'id1', 'id2'}
+    assert {hw['connected'] for hw in data} == {True}


### PR DESCRIPTION
Do not store every hardware-map parameter.
Fix loading empty hardware-map file.
Fix taking proper platform from loaded hardware-map file, if platform is missed in CLI.