### PR TITLE
Port --device-serial, --device-serial-pty

### DIFF
--- a/src/twister2/device/hardware_map.py
+++ b/src/twister2/device/hardware_map.py
@@ -9,7 +9,7 @@ import yaml
 @dataclass
 class HardwareMap:
     """Class keeps configuration for connected hardware."""
-    id: str
+    id: str = ''
     product: str = ''
     platform: str = ''
     runner: str = ''
@@ -18,6 +18,7 @@ class HardwareMap:
     notes: str = ''
     probe_id: str = ''
     serial: str = ''
+    serial_pty: str = ''
     baud: int = 115200
     pre_script: str = ''
     post_script: str = ''


### PR DESCRIPTION
Fix #143 

Added parameters:
```
--device-serial
--device-serial-baud
--device-serial-pty
```
Functionality is ported from Twister V1.

To test / compare with Twister V1, one can use following commands:
```
 ./scripts/twister -vv -c -T samples/hello_world -p nrf52840dk_nrf52840 --device-testing --device-serial /dev/ttyACM0

 pytest -s -v  --clear=delete samples/hello_world --device-testing  --platform=nrf52840dk_nrf52840 --device-serial=/dev/ttyACM0
```

To test `--device-serial-pty` I was created a simple script:
```
#!/usr/bin/env python3
import time
while True:
   print("Hello World! AAA")
   time.sleep(1)
```
and use it in comand:
```
./scripts/twister -vv -c -T samples/hello_world -p nrf52840dk_nrf52840 --device-testing --device-serial-pty $PWD/script.py

pytest -s -v  --clear=delete samples/hello_world --device-testing  --platform=nrf52840dk_nrf52840 --device-serial-pty=$PWD/script.py
```


