### PR TITLE
Port --west-flash and --west-runner options

### DIFF
--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -120,6 +120,18 @@ def pytest_addoption(parser: pytest.Parser):
              'E.g --device-testing --device-serial-pty=<script>'
     )
     twister_group.addoption(
+        '--west-flash',
+        action='store',
+        help='Extend parameters for west flash. '
+             'E.g. -device-testing -west-flash="--board-id=foobar,--erase" '
+             'will translate to "west flash -- --board-id=foobar --erase"'
+    )
+    twister_group.addoption(
+        '--west-runner',
+        action='store',
+        help='use the specified west runner. E.g. --west-runner=pyocd'
+    )
+    twister_group.addoption(
         '-G', '--integration',
         action='store_true',
         help='Run integration tests',
@@ -331,6 +343,11 @@ def validate_options(config: pytest.Config) -> None:
         pytest.exit(
             'No quarantine list given to be verified. '
             'Option `--quarantine-verify` must be used with `--quarantine-list`.'
+        )
+    if (config.option.west_flash or config.option.west_runner) \
+            and not config.option.device_testing:
+        pytest.exit(
+            'Options `--west-flash` or `--west-runner` must be used with `--device-testing`.'
         )
 
 

--- a/src/twister2/twister_config.py
+++ b/src/twister2/twister_config.py
@@ -41,6 +41,8 @@ class TwisterConfig:
     user_platform_filter: list[str] = field(default_factory=list, repr=False)
     used_toolchain_version: str = ''
     enable_slow: bool = False
+    west_flash: list[str] = field(default_factory=list, repr=False)
+    west_runner: str = ''
 
     def __post_init__(self):
         self.verify_platforms_existence(self.selected_platforms)
@@ -66,6 +68,10 @@ class TwisterConfig:
         architectures: list[str] = config.option.arch
         quarantine_verify: bool = config.option.quarantine_verify
         enable_slow: bool = config.option.enable_slow
+        west_flash: list[str] = []
+        if config.option.west_flash:
+            west_flash = [w.strip() for w in config.option.west_flash.split(',')]
+        west_runner: str = config.option.west_runner or ''
 
         hardware_map_list: list[HardwareMap] = _get_hardware_map_list(config)
         if not config.option.platform and hardware_map_list:
@@ -108,6 +114,8 @@ class TwisterConfig:
             user_platform_filter=user_platform_filter,
             used_toolchain_version=used_toolchain_version,
             enable_slow=enable_slow,
+            west_flash=west_flash,
+            west_runner=west_runner
         )
 
     def asdict(self) -> dict:

--- a/tests/device/hardware_adapter_test.py
+++ b/tests/device/hardware_adapter_test.py
@@ -192,3 +192,30 @@ def test_if_hardware_adapter_uses_serial_pty(patched_serial, patched_popen, devi
     device.disconnect()
     assert not device.connection
     assert not device.serial_pty_proc
+
+
+@mock.patch('twister2.device.hardware_adapter.shutil.which')
+def test_if_get_command_returns_proper_string_with_west_runner(patched_which, device) -> None:
+    patched_which.return_value = 'west'
+    device.twister_config.west_runner = 'pyocd'
+    device.hardware_map.runner = ''
+    device.hardware_map.id = ''
+    device.generate_command('src')
+    assert isinstance(device.command, list)
+    assert device.command == [
+        'west', 'flash', '--skip-rebuild', '--build-dir', 'src', '--runner', 'pyocd'
+    ]
+
+
+@mock.patch('twister2.device.hardware_adapter.shutil.which')
+def test_if_get_command_returns_proper_string_with_west_flash(patched_which, device) -> None:
+    patched_which.return_value = 'west'
+    device.twister_config.west_flash = ['--board-id=foobar', '--erase']
+    device.hardware_map.runner = 'pyocd'
+    device.hardware_map.id = ''
+    device.generate_command('src')
+    assert isinstance(device.command, list)
+    assert device.command == [
+        'west', 'flash', '--skip-rebuild', '--build-dir', 'src', '--runner', 'pyocd',
+        '--', '--board-id=foobar', '--erase'
+    ]

--- a/tests/twister2_plugin_test.py
+++ b/tests/twister2_plugin_test.py
@@ -30,6 +30,8 @@ def test_twister_help(pytester):
         '*--all*',
         '*-M {pass,all}, --runtime-artifact-cleanup={pass,all}*',
         '*--prep-artifacts-for-testing*',
+        '*--west-flash*',
+        '*--west-runner*',
     ])
 
 
@@ -199,6 +201,14 @@ def test_if_pytest_skip_twister_regular_tests_if_not_enabled(pytester, resources
         (
             '--device-serial=/dev/ACM0 --device-serial-pty=script.py',
             ['Exit: Not allowed to combine arguments:*']
+        ),
+        (
+            '--west-flash=--erase',
+            ['*must be used with `--device-testing`*']
+        ),
+        (
+            '--west-runner=jlink',
+            ['*must be used with `--device-testing`*']
         )
     ],
     ids=[
@@ -207,7 +217,9 @@ def test_if_pytest_skip_twister_regular_tests_if_not_enabled(pytester, resources
         'only_device_testing',
         'device_serial_with_more_platforms',
         'device_serial_without_platform',
-        'combined_with_device_serial'
+        'combined_with_device_serial',
+        'west_flash',
+        'west_runner'
     ]
 )
 def test_if_invalid_parameters_raises_error(pytester, resources, extend_command, expected):


### PR DESCRIPTION
Added options:
```
  --west-flash=WEST_FLASH
                        Extend parameters for west flash. E.g. -device-testing -west-flash="--board-
                        id=foobar,--erase" will translate to "west flash -- --board-id=foobar --erase"
  --west-runner=WEST_RUNNER
                        use the specified west runner. E.g. --west-runner=pyocd
```
This is ported from TwiterV1.
`--west-flash` must have an argument (similar as with `--clear` option, if left without argument and next a folder with tests is given, than that folder name is taken as an west-flash argument). In TwisterV2 `west` is the default flash tool, so using `--west-flash` to enable using west is not required.

To test one can use following commands:
```
/scripts/twister -vv -T samples/hello_world -p nrf9160dk_nrf9160 --device-testing --device-serial /dev/ttyACM0 --west-flash="--recover,--erase" --west-runner nrfjprog

pytest --twister samples/hello_world --platform=nrf9160dk_nrf9160 --device-testing --device-serial=/dev/ttyACM0 -s -vv --west-flash="--recover,--erase" --west-runner=nrfjprog
```

