### PR TITLE
Changes in regular tests generation to align platform scope

### DIFF
--- a/src/twister2/fixtures/common.py
+++ b/src/twister2/fixtures/common.py
@@ -60,7 +60,7 @@ class SetupTestManager:
             return State(
                 False,
                 'Skipping test after building because platform type is "mcu", '
-                'but device-testing was selected',
+                'but device-testing was not selected',
                 'Built but not executed because device-testing was not selected for platform type mcu'
             )
         if runnable is False:

--- a/src/twister2/generate_tests_plugin.py
+++ b/src/twister2/generate_tests_plugin.py
@@ -5,33 +5,16 @@ Test variants are generated for `platform` and `scenario`.
 
 from __future__ import annotations
 
-import itertools
 import logging
-from dataclasses import dataclass
-from pathlib import Path
 from typing import NamedTuple
 
 import pytest
 
-from twister2.helper import safe_load_yaml
-from twister2.platform_specification import PlatformSpecification
-from twister2.specification_processor import (
-    TEST_SPEC_FILE_NAME,
-    RegularSpecificationProcessor,
-)
+from twister2.specification_processor import RegularSpecificationProcessor
+from twister2.yaml_test_function import add_markers_from_specification
 from twister2.yaml_test_specification import YamlTestSpecification
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class Variant:
-    """Keeps information about single test variant"""
-    platform: PlatformSpecification
-    scenario: str
-
-    def __str__(self):
-        return f'{self.platform.identifier}:{self.scenario}'
 
 
 def get_scenarios_from_fixture(metafunc: pytest.Metafunc) -> list[str]:
@@ -39,27 +22,6 @@ def get_scenarios_from_fixture(metafunc: pytest.Metafunc) -> list[str]:
     if mark := metafunc.definition.get_closest_marker('build_specification'):
         return list(mark.args)
     return []
-
-
-def get_scenarios_from_yaml(spec_file: Path) -> list[str]:
-    """Return all available scenarios from yaml specification."""
-    data = safe_load_yaml(spec_file)
-    try:
-        return data['tests'].keys()
-    except KeyError:
-        return []
-
-
-def generate_yaml_test_specification_for_item(item: pytest.Item, variant: Variant) -> YamlTestSpecification | None:
-    """Add test specification from yaml file to test item."""
-    logger.debug('Adding test specification to item "%s"', item.nodeid)
-    scenario: str = variant.scenario
-    platform: PlatformSpecification = variant.platform
-
-    twister_config = item.config.twister_config  # type: ignore[attr-defined]
-    processor = RegularSpecificationProcessor(twister_config, item)
-    test_spec = processor.process(platform, scenario)
-    return test_spec
 
 
 class GenerateTestPlugin:
@@ -84,28 +46,23 @@ class GenerateTestPlugin:
 
         twister_config = metafunc.config.twister_config  # type: ignore[attr-defined]
 
-        platforms_list: list[PlatformSpecification] = [
-            platform for platform in twister_config.platforms
-            if platform.identifier in twister_config.preselected_platforms
-        ]
-        spec_file_path: Path = \
-            Path(metafunc.definition.fspath.dirname) / TEST_SPEC_FILE_NAME  # type: ignore[attr-defined]
         scenarios = get_scenarios_from_fixture(metafunc)
-        assert spec_file_path.exists(), f'There is no specification file for the test: {spec_file_path}'
-        if not scenarios:
-            scenarios = get_scenarios_from_yaml(spec_file_path)
-        variants = itertools.product(platforms_list, scenarios)
+        processor = RegularSpecificationProcessor(twister_config, metafunc.definition)
         params: list[NamedTuple] = []
-        for variant in variants:
-            v = Variant(*variant)
-            params.append(
-                pytest.param(v, marks=pytest.mark.platform(v.platform.identifier), id=str(v))
-            )
+        for platform, scenario in processor.get_test_configurations():
+            if scenarios and scenario not in scenarios:
+                continue
+            if test_spec := processor.process(platform, scenario):
+                id_name = f'{platform.identifier}:{scenario}'
+                params.append(
+                    pytest.param(test_spec, id=id_name)
+                )
 
-        # using indirect=True to inject value from `specification` fixture instead of param
-        metafunc.parametrize(
-            'specification', params, scope='function', indirect=True
-        )
+        if params:
+            # using indirect=True to inject value from `specification` fixture instead of param
+            metafunc.parametrize(
+                'specification', params, scope='function', indirect=True
+            )
 
     def pytest_collection_modifyitems(
         self,
@@ -114,20 +71,19 @@ class GenerateTestPlugin:
         if not hasattr(session, 'specifications'):
             session.specifications = {}  # type: ignore[attr-defined]
 
+        items_to_remove = []
         for item in items:
-            # add YAML test specification to session for consistency with python tests
-            if all([
-                hasattr(item.function, 'spec'),  # type: ignore[attr-defined]
-                item.nodeid not in session.specifications   # type: ignore[attr-defined]
-            ]):
-                session.specifications[item.nodeid] = item.function.spec  # type: ignore[attr-defined]
-            # yaml test function has no `callspec`
-            if not hasattr(item, 'callspec'):
+            if item.nodeid in session.specifications:  # type: ignore[attr-defined]
                 continue
-            if variant := item.callspec.params.get('specification'):  # type: ignore[attr-defined]
-                if spec := generate_yaml_test_specification_for_item(item, variant):
+            if hasattr(item, 'callspec'):  # type: ignore[attr-defined]
+                if spec := item.callspec.params.get('specification'):  # type: ignore[attr-defined]
+                    add_markers_from_specification(item, spec)
                     session.specifications[item.nodeid] = spec  # type: ignore[attr-defined]
+                    config.twister_config.selected_platforms.add(  # type: ignore[attr-defined]
+                        spec.platform
+                    )
+            # remove test with 'build_specification' marker, do not keep them as 'skipped'
+            elif item.get_closest_marker('build_specification'):
+                items_to_remove.append(item.nodeid)
 
-        # as we have all tests collected, update selected platform
-        for specification in session.specifications.values():  # type: ignore[attr-defined]
-            config.twister_config.selected_platforms.add(specification.platform)  # type: ignore[attr-defined]
+        items[:] = [item for item in items if item.nodeid not in items_to_remove]

--- a/src/twister2/load_tests.py
+++ b/src/twister2/load_tests.py
@@ -35,6 +35,9 @@ class LoadedTestData:
         with open(filename) as file:
             test_data = json.load(file)
         for ts in test_data['testsuites']:
+            if 'nodeid' in ts and '.py::' in ts['nodeid']:
+                logger.debug('Not supported for regular python tests: %s' % ts['nodeid'])
+                continue
             testdir, testname = ts['name'].rsplit('/', 1)
             testfile = Path(testdir) / 'testcase.yaml'
             if not testfile.exists():

--- a/src/twister2/plugin.py
+++ b/src/twister2/plugin.py
@@ -248,7 +248,7 @@ def pytest_addoption(parser: pytest.Parser):
         metavar='PATH',
         action='store',
         default=None,
-        help='load testplan from file'
+        help='load testplan from file. Note: regular python tests not supported'
     )
     twister_group.addoption(
         '--only-failed',
@@ -256,12 +256,6 @@ def pytest_addoption(parser: pytest.Parser):
         action='store_true',
         help='Run only those tests that failed the previous twister run invocation.'
     )
-    # twister_group.addoption(
-    #     '--test-only',
-    #     dest='test_only',
-    #     action='store_true',
-    #     help='Only run device tests with current artifacts, do not build the code'
-    # )
     twister_group.addoption(
         '--only-from-yaml',
         dest='only_from_yaml',

--- a/src/twister2/yaml_file.py
+++ b/src/twister2/yaml_file.py
@@ -38,6 +38,23 @@ class YamlPytestPlugin():
                 return True
         return False
 
+    def pytest_collection_modifyitems(
+        self,
+        session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
+    ):
+        if not hasattr(session, 'specifications'):
+            session.specifications = {}  # type: ignore[attr-defined]
+
+        for item in items:
+            if item.nodeid in session.specifications:  # type: ignore[attr-defined]
+                continue
+            # add YAML test specification to session for consistency with python tests
+            if hasattr(item.function, 'spec'):  # type: ignore[attr-defined]
+                session.specifications[item.nodeid] = item.function.spec  # type: ignore[attr-defined]
+                config.twister_config.selected_platforms.add(  # type: ignore[attr-defined]
+                    item.function.spec.platform  # type: ignore[attr-defined]
+                )
+
 
 class YamlModule(pytest.File):
     """Class for collecting tests from a yaml file."""


### PR DESCRIPTION
Align platform scope for regular python tests:
find changes in `GenerateTestPlugin::pytest_generate_tests`
`RegularSpecificationProcessor::get_test_configurations` is called, to select platform and scenarios.
If scenario is not selected, than item is removed in `pytest_collection_modifyitems` (do not mark as skipped for consistency with Yaml scenarios and to limit memory consumption).

`SpecificationProcessor::process` is now common for `YamlSpecificationProcessor` and `RegularSpecificationProcessor`,

`session.specifications[item.nodeid]` is updated separately for regular and yaml tests (in separate `pytest_collection_modifyitems`) to avoid mixing logic.